### PR TITLE
NIWebController _toolbar wrong autorelease issue.

### DIFF
--- a/src/webcontroller/src/NIWebController.m
+++ b/src/webcontroller/src/NIWebController.m
@@ -27,7 +27,10 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)releaseAllSubviews {
   _webView.delegate = nil;
-
+    
+  // stop loading before release
+  [_webView stopLoading];
+    
   NI_RELEASE_SAFELY(_actionSheet);
   NI_RELEASE_SAFELY(_webView);
   NI_RELEASE_SAFELY(_toolbar);
@@ -161,7 +164,7 @@
   CGRect toolbarFrame = CGRectMake(0, bounds.size.height - toolbarHeight,
                                    bounds.size.width, toolbarHeight);
 
-  _toolbar = [[[UIToolbar alloc] initWithFrame:toolbarFrame] autorelease];
+  _toolbar = [[UIToolbar alloc] initWithFrame:toolbarFrame];
   _toolbar.autoresizingMask =
   UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
 


### PR DESCRIPTION
When NIWebController is pushed into UINavigationController and then
popped, bad access error occurs due to wrong alloc/release call. I
removed 'autorelease' from _toolbar and added [_webView stopLoading]; to
stop loading when controller is deallocated.
