### PR TITLE
Interapp - Call custom application

### DIFF
--- a/examples/interapp/catalog/src/CatalogTableViewController.m
+++ b/examples/interapp/catalog/src/CatalogTableViewController.m
@@ -169,6 +169,21 @@ typedef BOOL (^BasicBlockReturnBool)(void);
             [NSDictionary dictionaryWithObjectsAndKeys: @"featherless", @"title",
              [^{ return [NIInterapp twitterProfileForUsername:@"featherless"];} autorelease], @"block", nil],
             
+
+            @"Custom Application",
+            [NSDictionary dictionaryWithObjectsAndKeys: @"Open custom app (RAWR:)", @"title",
+             [^{ return [NIInterapp applicationWithScheme:@"RAWR:"];} autorelease], @"block", nil],
+            [NSDictionary dictionaryWithObjectsAndKeys: @"Custom app or AppStore", @"title",
+             [^{ return [NIInterapp applicationWithScheme:@"RAWR:"
+                                            andAppStoreId:@"000000000"];} autorelease], @"block", nil],
+            [NSDictionary dictionaryWithObjectsAndKeys: @"Custom app with url", @"title",
+             [^{ return [NIInterapp applicationWithScheme:@"RAWR:" 
+                                                andPath:@"//friends/blah"];} autorelease], @"block", nil],
+            [NSDictionary dictionaryWithObjectsAndKeys: @"Custom app with url or AppStore", @"title",
+             [^{ return [NIInterapp applicationWithScheme:@"RAWR:" 
+                                               appStoreId:@"000000000" 
+                                                andPath:@"//friends/blah"];} autorelease], @"block", nil],
+            
             @"Instagram",
             [NSDictionary dictionaryWithObjectsAndKeys: @"Open the app", @"title",
              [^{ return [NIInterapp instagram];} autorelease], @"block", nil],

--- a/src/interapp/src/NIInterapp.h
+++ b/src/interapp/src/NIInterapp.h
@@ -91,6 +91,14 @@
 + (NSURL *)urlForInstagramImageAtFilePath:(NSString *)filePath error:(NSError **)error;
 + (NSString *)instagramAppStoreId;
 
+#pragma mark Custom Application
+
++ (BOOL)applicationIsInstalledWithScheme:(NSString *)applicationScheme;
++ (BOOL)applicationWithScheme:(NSString *)applicationScheme;
++ (BOOL)applicationWithScheme:(NSString *)applicationScheme andAppStoreId:(NSString *)appStoreId;
++ (BOOL)applicationWithScheme:(NSString *)applicationScheme andPath:(NSString *)path;
++ (BOOL)applicationWithScheme:(NSString *)applicationScheme appStoreId:(NSString *)appStoreId andPath:(NSString *)path;
+
 @end
 
 @interface NIMailAppInvocation : NSObject {
@@ -280,6 +288,47 @@
  * The Twitter App Store ID.
  *
  *      @fn NIInterapp::twitterAppStoreId
+ */
+
+
+/** @name Custom Application **/
+
+/**
+ * Returns YES if the supplied application is installed.
+ *
+ *      @fn NIInterapp::applicationIsInstalledWithScheme
+ */
+
+/**
+ * Opens the supplied application.
+ *
+ *      @fn NIInterapp::applicationWithScheme
+ */
+
+/**
+ * Opens the supplied application. If the supplied application is not installed, will open the
+ * App Store to the specified ID download page.
+ *
+ *      @fn NIInterapp::applicationWithScheme:andAppStoreId
+ */
+
+/**
+ * Opens the supplied application.
+ *
+ *      @fn NIInterapp::applicationWithScheme:andPath
+ */
+
+/**
+ * Opens the supplied application, to the specified path. If the supplied application is not installed, will open the
+ * App Store to the download page for the specified AppStoreId.
+ *
+ *      @fn NIInterapp::applicationWithScheme:appStoreId:andPath
+ */
+
+/**
+ * Opens the application with the supplied custom URL.
+ *
+ *      @fn NIInterapp::applicationWithUrl:
  */
 
 

--- a/src/interapp/src/NIInterapp.m
+++ b/src/interapp/src/NIInterapp.m
@@ -322,6 +322,72 @@ static NSString* const sTwitterScheme = @"twitter:";
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
+#pragma mark Application
+
+//static NSString* const sTwitterScheme = @"twitter:";
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (BOOL)applicationIsInstalledWithScheme:(NSString *)applicationScheme {
+    return [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:applicationScheme]];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (BOOL)applicationWithScheme:(NSString *)applicationScheme {
+    return [self applicationWithScheme:applicationScheme
+                            appStoreId:nil
+                               andPath:nil];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (BOOL)applicationWithScheme:(NSString *)applicationScheme
+                andAppStoreId:(NSString *)appStoreId {
+    return [self applicationWithScheme:applicationScheme
+                            appStoreId:appStoreId
+                               andPath:nil];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (BOOL)applicationWithScheme:(NSString *)applicationScheme
+                      andPath:(NSString *)path {
+    return [self applicationWithScheme:applicationScheme
+                            appStoreId:nil
+                               andPath:path];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (BOOL)applicationWithScheme:(NSString *)applicationScheme
+                   appStoreId:(NSString *)appStoreId
+                      andPath:(NSString *)path {
+    BOOL        didOpen = false;
+    NSString*   urlPath = applicationScheme;
+    
+    // Were we passed a path?
+    if (path != nil) {
+        // Generate the full application URL
+        urlPath = [urlPath stringByAppendingFormat:@"%@", path];
+    }
+    
+    // Try to open the application URL
+    didOpen = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlPath]];
+    
+    // Didn't open and we have an appStoreId
+    if (!didOpen && appStoreId != nil) {
+        // Open the app store instead
+        didOpen = [self appStoreWithAppId:appStoreId];
+    }
+    
+    return didOpen;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
 #pragma mark Instagram
 
 static NSString* const sInstagramScheme = @"instagram:";


### PR DESCRIPTION
- Added functions that allow the developer to specify custom
  application schemes and paths to call using interapp, optionally
  displaying the App Store page for the specified AppStoreId
- Updated example to show use of these new functions.
