### PR TITLE
Fix a crash in ModelCatalog. To repro, just launch that app and tap on "Form Cells" on iOS < 5.

### DIFF
--- a/examples/models/ModelCatalog/ModelCatalog/src/FormCellCatalogTableViewController.m
+++ b/examples/models/ModelCatalog/ModelCatalog/src/FormCellCatalogTableViewController.m
@@ -111,7 +111,7 @@
 
     } else {
       // We must always handle the else case because cells can be reused.
-      textInputCell.textField.textColor = nil;
+      textInputCell.textField.textColor = [UIColor blackColor];
     }
   }
 }


### PR DESCRIPTION
Fix a crash in the ModelCatalog example. UITextField doesn't like nil as an argument to setTextColor (at least on iOS < 5).
