### PR TITLE
Updated Nimbus Network Image for ARC

### DIFF
--- a/examples/networkimage/BasicNetworkImage/BasicNetworkImage.xcodeproj/project.pbxproj
+++ b/examples/networkimage/BasicNetworkImage/BasicNetworkImage.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -35,16 +35,16 @@
 		66EA06C613C01D9D004FFE1A /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66EA06BE13C01D7B004FFE1A /* SystemConfiguration.framework */; };
 		66EA06C913C01DA8004FFE1A /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66EA06B613C01D6E004FFE1A /* MobileCoreServices.framework */; };
 		66EA070C13C01F2F004FFE1A /* nimbus64x64.png in Resources */ = {isa = PBXBuildFile; fileRef = 66EA070B13C01F2F004FFE1A /* nimbus64x64.png */; };
-		66EA0C8713C05DCF004FFE1A /* ASIAuthenticationDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C6F13C05DCE004FFE1A /* ASIAuthenticationDialog.m */; };
-		66EA0C8813C05DCF004FFE1A /* ASIDataCompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7213C05DCE004FFE1A /* ASIDataCompressor.m */; };
-		66EA0C8913C05DCF004FFE1A /* ASIDataDecompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7413C05DCE004FFE1A /* ASIDataDecompressor.m */; };
-		66EA0C8A13C05DCF004FFE1A /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7613C05DCE004FFE1A /* ASIDownloadCache.m */; };
-		66EA0C8B13C05DCF004FFE1A /* ASIFormDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7813C05DCF004FFE1A /* ASIFormDataRequest.m */; };
-		66EA0C8C13C05DCF004FFE1A /* ASIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7A13C05DCF004FFE1A /* ASIHTTPRequest.m */; };
-		66EA0C8D13C05DCF004FFE1A /* ASIInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7E13C05DCF004FFE1A /* ASIInputStream.m */; };
-		66EA0C8E13C05DCF004FFE1A /* ASINetworkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C8013C05DCF004FFE1A /* ASINetworkQueue.m */; };
-		66EA0C8F13C05DCF004FFE1A /* NIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C8313C05DCF004FFE1A /* NIHTTPRequest.m */; };
-		66EA0C9013C05DCF004FFE1A /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C8613C05DCF004FFE1A /* Reachability.m */; };
+		66EA0C8713C05DCF004FFE1A /* ASIAuthenticationDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C6F13C05DCE004FFE1A /* ASIAuthenticationDialog.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C8813C05DCF004FFE1A /* ASIDataCompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7213C05DCE004FFE1A /* ASIDataCompressor.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C8913C05DCF004FFE1A /* ASIDataDecompressor.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7413C05DCE004FFE1A /* ASIDataDecompressor.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C8A13C05DCF004FFE1A /* ASIDownloadCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7613C05DCE004FFE1A /* ASIDownloadCache.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C8B13C05DCF004FFE1A /* ASIFormDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7813C05DCF004FFE1A /* ASIFormDataRequest.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C8C13C05DCF004FFE1A /* ASIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7A13C05DCF004FFE1A /* ASIHTTPRequest.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C8D13C05DCF004FFE1A /* ASIInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C7E13C05DCF004FFE1A /* ASIInputStream.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C8E13C05DCF004FFE1A /* ASINetworkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C8013C05DCF004FFE1A /* ASINetworkQueue.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C8F13C05DCF004FFE1A /* NIHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C8313C05DCF004FFE1A /* NIHTTPRequest.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		66EA0C9013C05DCF004FFE1A /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EA0C8613C05DCF004FFE1A /* Reachability.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		66EA0F1E13C20BFD004FFE1A /* README.mdown in Resources */ = {isa = PBXBuildFile; fileRef = 66EA0F1D13C20BFD004FFE1A /* README.mdown */; };
 /* End PBXBuildFile section */
 
@@ -338,8 +338,11 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0420;
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "BasicNetworkImage" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -442,12 +445,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
-				PREBINDING = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -457,13 +460,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
-				PREBINDING = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/examples/networkimage/BasicNetworkImage/src/AppDelegate.m
+++ b/examples/networkimage/BasicNetworkImage/src/AppDelegate.m
@@ -31,15 +31,6 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)dealloc {
-  NI_RELEASE_SAFELY(_window);
-  NI_RELEASE_SAFELY(_rootController);
-
-  [super dealloc];
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 #pragma mark Application lifecycle
@@ -48,7 +39,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (BOOL)              application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  self.window = [[[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds] autorelease];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 
   // Try experimenting with the maximum number of concurrent operations here.
   // By making it one, we force the network operations to happen serially. This can be

--- a/examples/networkimage/BasicNetworkImage/src/RootViewController.m
+++ b/examples/networkimage/BasicNetworkImage/src/RootViewController.m
@@ -36,8 +36,7 @@ static const CGFloat kImageSpacing = 10;
   UIImage* initialImage = [UIImage imageWithContentsOfFile:
                            NIPathForBundleResource(nil, @"nimbus64x64.png")];
 
-  NINetworkImageView* networkImageView = [[[NINetworkImageView alloc] initWithImage:initialImage]
-                                          autorelease];
+  NINetworkImageView* networkImageView = [[NINetworkImageView alloc] initWithImage:initialImage];
   networkImageView.delegate = self;
   networkImageView.contentMode = UIViewContentModeCenter;
 
@@ -126,13 +125,12 @@ static const CGFloat kImageSpacing = 10;
   [self.view addSubview:_memoryUsageLabel];
 
 
-  UIView* bottomBorder = [[[UIView alloc] initWithFrame:
+  UIView* bottomBorder = [[UIView alloc] initWithFrame:
                            CGRectMake(0,
                                       CGRectGetMaxY(_memoryUsageLabel.frame)
                                       + kTextBottomMargin - 1,
                                       self.view.frame.size.width,
-                                      1)]
-                          autorelease];
+                                      1)];
   bottomBorder.autoresizingMask = (UIViewAutoresizingFlexibleWidth
                                    | UIViewAutoresizingFlexibleBottomMargin);
   bottomBorder.backgroundColor = [UIColor whiteColor];
@@ -142,10 +140,9 @@ static const CGFloat kImageSpacing = 10;
 
   _networkImageViews = [[NSMutableArray alloc] init];
 
-  _scrollView = [[[UIScrollView alloc] initWithFrame:
+  _scrollView = [[UIScrollView alloc] initWithFrame:
                   NIRectShift(self.view.bounds,
-                              0, CGRectGetMaxY(_memoryUsageLabel.frame) + kTextBottomMargin)]
-                 autorelease];
+                              0, CGRectGetMaxY(_memoryUsageLabel.frame) + kTextBottomMargin)];
   _scrollView.backgroundColor = [UIColor colorWithWhite:0.1 alpha:1];
   _scrollView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
   _scrollView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
@@ -178,7 +175,7 @@ static const CGFloat kImageSpacing = 10;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)viewDidUnload {
-  NI_RELEASE_SAFELY(_networkImageViews);
+  _networkImageViews = nil;
   _scrollView = nil;
 
   [super viewDidUnload];

--- a/examples/networkimage/BasicNetworkImage/src/main.m
+++ b/examples/networkimage/BasicNetworkImage/src/main.m
@@ -15,10 +15,10 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "AppDelegate.h"
 
 int main(int argc, char *argv[]) {
-  NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-  int retVal = UIApplicationMain(argc, argv, nil, @"AppDelegate");
-  [pool release];
-  return retVal;
+  @autoreleasepool {
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+  }
 }

--- a/src/Nimbus.xcodeproj/project.pbxproj
+++ b/src/Nimbus.xcodeproj/project.pbxproj
@@ -3302,6 +3302,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/NimbusNetworkImage.dst;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -3327,6 +3328,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = YES;
 				DSTROOT = /tmp/NimbusNetworkImage.dst;
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/src/networkimage/src/NIHTTPImageRequest.m
+++ b/src/networkimage/src/NIHTTPImageRequest.m
@@ -34,14 +34,6 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)dealloc {
-  NI_RELEASE_SAFELY(_imageCroppedAndSizedForDisplay);
-
-  [super dealloc];
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)initWithURL:(NSURL *)newURL {
   if ((self = [super initWithURL:newURL])) {
     self.imageCropRect = CGRectZero;
@@ -130,11 +122,10 @@
                                                            scaleOptions: self.scaleOptions
                                                    interpolationQuality: self.interpolationQuality]];
 
-  NI_RELEASE_SAFELY(image);
+  image = nil;
 
   [super requestFinished];
 }
-
 
 @end
 

--- a/src/networkimage/src/NINetworkImageView.h
+++ b/src/networkimage/src/NINetworkImageView.h
@@ -72,7 +72,7 @@ typedef enum {
   NSOperationQueue*     _networkOperationQueue;
 
   // Delegation
-  id<NINetworkImageViewDelegate> _delegate;
+  __unsafe_unretained id<NINetworkImageViewDelegate> _delegate;
 }
 
 #pragma mark Creating a Network Image View

--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -73,20 +73,6 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)dealloc {
   [self cancelOperation];
-
-  NI_RELEASE_SAFELY(_operation);
-
-  NI_RELEASE_SAFELY(_initialImage);
-
-  NI_RELEASE_SAFELY(_imageMemoryCache);
-  NI_RELEASE_SAFELY(_imageDiskCache);
-  NI_RELEASE_SAFELY(_networkOperationQueue);
-
-  NI_RELEASE_SAFELY(_memoryCachePrefix);
-
-  NI_RELEASE_SAFELY(_lastPathToNetworkImage);
-
-  [super dealloc];
 }
 
 
@@ -457,8 +443,7 @@
 - (void)setInitialImage:(UIImage *)initialImage {
   if (_initialImage != initialImage) {
     BOOL updateViewImage = (_initialImage == self.image);
-    [_initialImage release];
-    _initialImage = [initialImage retain];
+    _initialImage = initialImage;
 
     if (updateViewImage) {
       [self setImage:_initialImage];
@@ -481,8 +466,7 @@
     queue = [Nimbus networkOperationQueue];
   }
   if (queue != _networkOperationQueue) {
-    [_networkOperationQueue release];
-    _networkOperationQueue = [queue retain];
+    _networkOperationQueue = queue;
   }
 }
 


### PR DESCRIPTION
Example app also updated.

Note: All ASIHTTPRequest Objects in the example app have ARC disabled via the `-fno-objc-arc` compiler flag. 
Also ASIHTTPRequest throws a warning:

```
nimbus/examples/networkimage/BasicNetworkImage/../../../src/ASIHTTPRequest/src/ASIHTTPRequest.m:16:
nimbus/examples/networkimage/BasicNetworkImage/../../../src/ASIHTTPRequest/src/Reachability/Reachability.h:154:59: warning: declaration of 'struct sockaddr_in' will not be visible outside of this function [3]
 + (Reachability *) reachabilityWithAddress: (const struct sockaddr_in*) hostAddress;
```

ASIHTTPRequest is not our project to fix :)
