### PR TITLE
imageview is empty with invalid image from network

### DIFF
--- a/src/networkimage/src/NIHTTPImageRequest.m
+++ b/src/networkimage/src/NIHTTPImageRequest.m
@@ -116,22 +116,24 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)requestFinished {
   NSData* responseData = [self responseData];
+    
   UIImage* image = [[UIImage alloc] initWithData:responseData];
 
   // Clear out the data as quickly as we can. We never use the response data in the
   // NINetworkImageView object, so this avoids doubling our memory on every thread.
   [self setRawResponseData:nil];
 
-  // Slice it, dice it!
-  [self setImageCroppedAndSizedForDisplay:[[self class] imageFromSource: image
-                                                        withContentMode: self.imageContentMode
-                                                               cropRect: self.imageCropRect
-                                                            displaySize: self.imageDisplaySize
-                                                           scaleOptions: self.scaleOptions
-                                                   interpolationQuality: self.interpolationQuality]];
+  // Slice it, dice it! (only with a valid image!)
+  if (image) {
+    [self setImageCroppedAndSizedForDisplay:[[self class] imageFromSource: image
+                                                          withContentMode: self.imageContentMode
+                                                                 cropRect: self.imageCropRect
+                                                              displaySize: self.imageDisplaySize
+                                                             scaleOptions: self.scaleOptions
+                                                     interpolationQuality: self.interpolationQuality]];
 
+  }
   NI_RELEASE_SAFELY(image);
-
   [super requestFinished];
 }
 

--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -127,13 +127,13 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)initWithCoder:(NSCoder *)aDecoder {
-  if ((self = [super initWithCoder:aDecoder])) {
-    if (nil != self.image) {
-      self.initialImage = self.image;
+    if ((self = [super initWithCoder:aDecoder])) {
+        if (nil != self.image) {
+            self.initialImage = self.image;
+        }
+        [self assignDefaults];
     }
-    [self assignDefaults];
-  }
-  return self;
+    return self;
 }
 
 
@@ -193,22 +193,25 @@
                        contentMode: (UIViewContentMode)contentMode
                       scaleOptions: (NINetworkImageViewScaleOptions)scaleOptions
                     expirationDate: (NSDate *)expirationDate {
-  // Store the result image in the memory cache.
-  if (nil != self.imageMemoryCache) {
-    NSString* cacheKey = [self cacheKeyForURL: url
-                                    imageSize: displaySize
-                                  contentMode: contentMode
-                                 scaleOptions: scaleOptions];
+  // Store and display only if a valid image is returned
+  if (image) {
+    // Store the result image in the memory cache.
+    if (nil != self.imageMemoryCache) {
+      NSString* cacheKey = [self cacheKeyForURL: url
+                                      imageSize: displaySize
+                                    contentMode: contentMode
+                                   scaleOptions: scaleOptions];
 
-    // Store the image in the memory cache, possibly with an expiration date.
-    [self.imageMemoryCache storeObject: image
-                              withName: cacheKey
-                          expiresAfter: expirationDate];
+      // Store the image in the memory cache, possibly with an expiration date.
+      [self.imageMemoryCache storeObject: image
+                                withName: cacheKey
+                            expiresAfter: expirationDate];
+    }
+
+    // Display the new image.
+    [self setImage:image];
   }
-
-  // Display the new image.
-  [self setImage:image];
-
+    
   self.operation = nil;
 
   if ([self.delegate respondsToSelector:@selector(networkImageView:didLoadImage:)]) {


### PR DESCRIPTION
the image will be processed and displayed only if the response data is a valid image.

case:
if the server (Apache for ex.) reply with a forbidden (or not found) page (html) the nsimage is 0x0 and the imageview will be empty.

expected:
the initial image shoud be still shown.
