### PR TITLE
[core] Add convenience function for /Library/Caches.

### DIFF
--- a/src/core/src/NIPaths.h
+++ b/src/core/src/NIPaths.h
@@ -45,6 +45,14 @@ NSString* NIPathForBundleResource(NSBundle* bundle, NSString* relativePath);
 NSString* NIPathForDocumentsResource(NSString* relativePath);
 
 
+/**
+ * Create a path with the caches directory and the relative path appended.
+ *
+ *      @returns The caches path concatenated with the given relative path.
+ */
+NSString* NIPathForCachesResource(NSString* relativePath);
+
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /**@}*/// End of Paths ////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/src/NIPaths.m
+++ b/src/core/src/NIPaths.m
@@ -37,3 +37,17 @@ NSString* NIPathForDocumentsResource(NSString* relativePath) {
   }
   return [documentsPath stringByAppendingPathComponent:relativePath];
 }
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+NSString* NIPathForCachesResource(NSString* relativePath)
+{
+  static NSString* cachesPath = nil;
+  if (nil == cachesPath) {
+    NSArray* dirs = NSSearchPathForDirectoriesInDomains(NSCachesDirectory,
+                                                        NSUserDomainMask,
+                                                        YES);
+    cachesPath = [[dirs objectAtIndex:0] retain];
+  }
+  return [cachesPath stringByAppendingPathComponent:relativePath];
+}


### PR DESCRIPTION
How do you feel about adding `NIPathForCachesResource()`, analogous to `NIPathForDocumentsResource()`?
