### PR TITLE
Arc compatibiltiy in NIPhotoAlbumScrollView.m

### DIFF
--- a/src/photos/src/NIPhotoAlbumScrollView.m
+++ b/src/photos/src/NIPhotoAlbumScrollView.m
@@ -200,7 +200,6 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setPhotoViewBackgroundColor:(UIColor *)photoViewBackgroundColor {
   if (_photoViewBackgroundColor != photoViewBackgroundColor) {
-      self.photoViewBackgroundColor = nil;
       self.photoViewBackgroundColor = photoViewBackgroundColor;
     
     for (UIView<NIPagingScrollViewPage>* page in self.visiblePages) {


### PR DESCRIPTION
no longer using release and retain, setting property to nil and assigning.  this allows the photo module to compile in the arc branch.
