### PR TITLE
call networkImageViewDidLoadImage for cached images too

### DIFF
--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -377,6 +377,7 @@
         [self.delegate networkImageView:self didLoadImage:self.image];
       }
 
+      [self networkImageViewDidLoadImage:image];
     } else {
       // Unable to load the image from memory, so let's fire off the operation now.
       operation.delegate = self;


### PR DESCRIPTION
NINetworkImageView should call networkImageViewDidLoadImage even if the image comes from the cache. That gives the user a chance to react to the image if necessary no matter where it came from.

Thanks!
