### PR TITLE
Incorrect parameter causing very infrequent crashes.

### DIFF
--- a/src/core/src/NIOperations.m
+++ b/src/core/src/NIOperations.m
@@ -98,7 +98,7 @@
                                              cachePolicy:self.cachePolicy
                                          timeoutInterval:self.timeout];
 
-    NSError* networkError = nil;
+    NSError* networkError = NULL;
     NSURLResponse* response = nil;
     NSData* data  = [NSURLConnection sendSynchronousRequest:request
                                           returningResponse:&response


### PR DESCRIPTION
This is a 3 character change. I've change a referenced parameters value to NULL instead of nil when setting up a NSURLConnection see:

https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Classes/NSURLConnection_Class/Reference/Reference.html

Hard to reproduce, but I've had several crash on that method invokation, and the documentation wants a NULL value, so figure why not make the change.
