### PR TITLE
NITextInputFormElement modifications

### DIFF
--- a/src/models/src/NIFormCellCatalog.m
+++ b/src/models/src/NIFormCellCatalog.m
@@ -255,6 +255,8 @@
     self.selectionStyle = UITableViewCellSelectionStyleNone;
 
     _textField = [[UITextField alloc] init];
+    [_textField setTag:self.element.elementID];
+    [_textField setAdjustsFontSizeToFitWidth:YES];
     [_textField addTarget:self action:@selector(textFieldDidChangeValue) forControlEvents:UIControlEventAllEditingEvents];
     [self.contentView addSubview:_textField];
 


### PR DESCRIPTION
Set the text field tag to the element ID for identifying the text field when using the delegate methods. This is particularly useful when you're attempting to validate the data within the text field and you need to know which one it is. 

Setting the adjustFontSizeToFitWidth flag also removes the truncated placeholder or text field text.
