### PR TITLE
Adding at least 404 error code support (and more)

### DIFF
--- a/src/core/src/NIOperations.m
+++ b/src/core/src/NIOperations.m
@@ -104,6 +104,18 @@
                                           returningResponse:&response
                                                       error:&networkError];
 
+    // If we get a 404 error, the network error will not everytime be filled with
+    // an error, so it will not fail with error, but will finish. We should check
+    // if in the response the status code is different from a 200 status code ok.
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+      NSHTTPURLResponse * httpResponse = (NSHTTPURLResponse *)response;
+      if ([httpResponse statusCode] != 200) {
+        networkError = [NSError errorWithDomain:@"nimbus" 
+                                           code:[httpResponse statusCode] 
+                                       userInfo:nil];
+      }
+    }
+      
     if (nil != networkError) {
       [self operationDidFailWithError:networkError];
 


### PR DESCRIPTION
... with error when a status code different from 200 is received from the request in case of an image load

When an image is loaded with NINetworkImageView, even if the request returns a 404, the delegate receive a didFinishCall. This is wrong. The delegate needs to know that the image could not be loaded. 

So I did modify the NIOperations so that in the case of images download, if it is an NSHTTPURLResponse, and if the status code is different from 200, we create an error object that will be catch by the next instruction.
And will then call didFailWithError.
