### PR TITLE
Don't disable user interaction of attributed label

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -568,8 +568,9 @@
 
   NSMutableAttributedString* attributedStringWithLinks =
     [self mutableAttributedStringWithLinkStylesApplied];
-  self.userInteractionEnabled = (_detectedlinkLocations.count > 0
-                                 || _explicitLinkLocations.count > 0);
+  if (_detectedlinkLocations.count > 0 || _explicitLinkLocations.count > 0) {
+    self.userInteractionEnabled = YES;
+  }
 
   if (nil != attributedStringWithLinks) {
     CGContextRef ctx = UIGraphicsGetCurrentContext();


### PR DESCRIPTION
Current implementation of NIAttributedLabel sets userInteractionEnabled to YES, when label contains links and resets it to NO when there are no links. This behavior doesn't allow to use label with gesture recognizers, and there is no obvious way to enable user interaction for attributed label without links.
Proposed patch changes behavior of a label, so thats it sets userInteractionEnabled to YES when label contains links and doesn't change the value if there is no links. This allows to manually enable it and attach gesture recognizers to it.
