### PR TITLE
Unrecovered NSGenericException while parsing CSS file

### DIFF
--- a/src/Nimbus.xcodeproj/project.pbxproj
+++ b/src/Nimbus.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		66FE7D6B13FB83620061B987 /* NimbusModels.h in Headers */ = {isa = PBXBuildFile; fileRef = 66FE7D6413FB83620061B987 /* NimbusModels.h */; };
 		66FE7D6C13FB83620061B987 /* NITableViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 66FE7D6513FB83620061B987 /* NITableViewModel.h */; };
 		66FE7D6D13FB83620061B987 /* NITableViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 66FE7D6613FB83620061B987 /* NITableViewModel.m */; };
+		8E99FC72153F0AB5004ADD0A /* exception.css in Resources */ = {isa = PBXBuildFile; fileRef = 8E99FC71153F0AB5004ADD0A /* exception.css */; };
 		DB3A231713FD4B8E00614220 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66A03C1A13E6E85E00B514F3 /* SenTestingKit.framework */; };
 		DB3A231913FD4B8E00614220 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66A03C0C13E6E85E00B514F3 /* Foundation.framework */; };
 		DB3A231D13FD4B8E00614220 /* libNimbusAttributedLabel.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3A230913FD4B8E00614220 /* libNimbusAttributedLabel.a */; };
@@ -847,6 +848,7 @@
 		66FE7D6513FB83620061B987 /* NITableViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NITableViewModel.h; sourceTree = "<group>"; };
 		66FE7D6613FB83620061B987 /* NITableViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NITableViewModel.m; sourceTree = "<group>"; };
 		66FE7D6813FB83620061B987 /* NimbusModelsTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "NimbusModelsTests-Info.plist"; sourceTree = "<group>"; };
+		8E99FC71153F0AB5004ADD0A /* exception.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = exception.css; path = css/unittests/exception.css; sourceTree = SOURCE_ROOT; };
 		DB3A230913FD4B8E00614220 /* libNimbusAttributedLabel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libNimbusAttributedLabel.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB3A231613FD4B8E00614220 /* NimbusAttributedLabelTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbusAttributedLabelTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB3A233213FD4BE500614220 /* NIAttributedLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NIAttributedLabel.h; sourceTree = "<group>"; };
@@ -1435,6 +1437,7 @@
 				66FCC632144FB42E0029F1A6 /* includee.css */,
 				66FCC633144FB42E0029F1A6 /* includer.css */,
 				66832CC9143D7994003E413C /* NimbusCSSTests-Info.plist */,
+				8E99FC71153F0AB5004ADD0A /* exception.css */,
 			);
 			name = resources;
 			sourceTree = "<group>";
@@ -2737,6 +2740,7 @@
 				66832CFF143E3294003E413C /* UILabel.css in Resources */,
 				66FCC634144FB42E0029F1A6 /* includee.css in Resources */,
 				66FCC635144FB42E0029F1A6 /* includer.css in Resources */,
+				8E99FC72153F0AB5004ADD0A /* exception.css in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/css/src/NICSSParser.m
+++ b/src/css/src/NICSSParser.m
@@ -238,7 +238,7 @@ int cssConsume(char* text, int token) {
               // Merge the orders.
               {
                 NSMutableArray* order = [existingProperties objectForKey:kPropertyOrderKey];
-                [order addObjectsFromArray:[_mutatingRuleset objectForKey:kPropertyOrderKey]];
+                [order addObjectsFromArray:[NSArray arrayWithArray:[_mutatingRuleset objectForKey:kPropertyOrderKey]]];
                 [_mutatingRuleset setObject:order forKey:kPropertyOrderKey];
               }
 
@@ -247,7 +247,7 @@ int cssConsume(char* text, int token) {
               }
               // Add the order of the new properties.
               [[existingProperties objectForKey:kPropertyOrderKey] addObjectsFromArray:
-               [_mutatingRuleset objectForKey:kPropertyOrderKey]];
+               [NSArray arrayWithArray:[_mutatingRuleset objectForKey:kPropertyOrderKey]]];
             }
           }
 

--- a/src/css/unittests/exception.css
+++ b/src/css/unittests/exception.css
@@ -1,0 +1,9 @@
+.className
+{
+    font-size: 16;
+}
+
+.className
+{
+    color: #AAAAAA;
+}


### PR DESCRIPTION
```
Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <__NSArrayM: 0x5db8f00> was mutated while being enumerated.(
"font-size",
color,
"font-size"
)'
```

Apparently there is a case where the '**kRuleSetOrder**' array under 'existingProperties' and '_mutatingRuleset' will be the same. Couldn't reproduce it with a test but have managed to identify a potential minimum .css that triggers. There are however other preconditions that must exist. Since the preconditions can't be pinpointed, can't be sure if they are part of a valid NimbusCSSParser state.
