### PR TITLE
Forward all UIScrollViewDelegate methods to the NIPagingScrollView delegate

### DIFF
--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -21,6 +21,8 @@
 #import "NIPagingScrollViewDelegate.h"
 #import "NimbusCore.h"
 
+#import <objc/runtime.h>
+
 const NSInteger NIPagingScrollViewUnknownNumberOfPages = -1;
 const CGFloat NIPagingScrollViewDefaultPageHorizontalMargin = 10;
 
@@ -399,6 +401,50 @@ const CGFloat NIPagingScrollViewDefaultPageHorizontalMargin = 10;
   if ([self.delegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)]) {
     [self.delegate scrollViewDidEndDecelerating:scrollView];
   }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark Forwarding unimplemented UIScrollViewDelegate methods
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)shouldForwardSelectorToDelegate:(SEL)aSelector
+{
+    struct objc_method_description description;
+    description = protocol_getMethodDescription(@protocol(UIScrollViewDelegate),
+                                                aSelector,
+                                                NO,
+                                                YES);
+    BOOL isSelectorInScrollViewDelegate = (description.name != NULL && description.types != NULL);
+    
+    return (   isSelectorInScrollViewDelegate
+            && [self.delegate respondsToSelector:aSelector]);
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    if ([super respondsToSelector:aSelector] == YES) {
+        return YES;
+    
+    } else {
+        return [self shouldForwardSelectorToDelegate:aSelector];
+    }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+    if ([self shouldForwardSelectorToDelegate:aSelector]) {
+        return self.delegate;
+    
+    } else {
+        return nil;
+    }
 }
 
 


### PR DESCRIPTION
NIPagingScrollView claims to implement the UIScrollViewDelegate protocol, but will silently swallow most of these methods.

This is annoying in many cases. For instance, it prevents the clients of NIPagingScrollView to implement properly an UIPageControl with deferred updates (as deferring the updates requires the – scrollViewDidEndScrollingAnimation: method).

Instead of manually implementing and forwarding all the methods UIScrollViewDelegate methods methods, this patch uses the NSObject message forwarding facility. It's much shorter than the manual implementation, not much more complicated, and safe if new methods are UIScrollViewDelegate in the future.
