### PR TITLE
Suppresses errors and properly references in RadioGroupController 

### DIFF
--- a/src/models/src/NIRadioGroupController.m
+++ b/src/models/src/NIRadioGroupController.m
@@ -20,6 +20,9 @@
 #import "NIRadioGroup.h"
 #import "NITableViewModel.h"
 
+#import "NIDebuggingTools.h"
+#import "NIDeviceOrientation.h"
+
 @interface NIRadioGroupController ()
 @property (nonatomic, readonly, retain) NIRadioGroup* radioGroup;
 @property (nonatomic, readonly, retain) id<NICell> tappedCell;


### PR DESCRIPTION
 in cases where not all core files are included in Prefix.
