### PR TITLE
Fixed compiler error due to invalid synthesizer.

### DIFF
--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -45,7 +45,6 @@
 @synthesize networkOperationQueue   = _networkOperationQueue;
 @synthesize maxAge                  = _maxAge;
 @synthesize initialImage            = _initialImage;
-@synthesize memoryCachePrefix       = _memoryCachePrefix;
 @synthesize delegate                = _delegate;
 
 


### PR DESCRIPTION
Looks like an oversight during the removal of memory cache prefix code.
