### PR TITLE
ARC is complaining about having a synthesize with no property definition

### DIFF
--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -45,7 +45,6 @@
 @synthesize networkOperationQueue   = _networkOperationQueue;
 @synthesize maxAge                  = _maxAge;
 @synthesize initialImage            = _initialImage;
-@synthesize memoryCachePrefix       = _memoryCachePrefix;
 @synthesize delegate                = _delegate;
 
 


### PR DESCRIPTION
It seems like this line came back from the dead. This just deletes it.
