### PR TITLE
[attributedlabel] long press on a link

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -50,6 +50,8 @@
   CTUnderlineStyleModifiers _underlineStyleModifier;
 
   id<NIAttributedLabelDelegate> _delegate;
+	
+  NSTimer *_longPressTimer;
 }
 
 /**
@@ -237,5 +239,12 @@
 -(void)attributedLabel:(NIAttributedLabel*)attributedLabel 
          didSelectLink:(NSURL*)url 
                atPoint:(CGPoint)point;
+
+
+/**
+ * Called when the user keep pressed a detected link for a while.
+ */
+-(void)attributedLabel:(NIAttributedLabel*)attributedLabel 
+      didLongPressLink:(NSURL*)url;
 
 @end


### PR DESCRIPTION
at the moment the commit does not completely comply to the code guidelines, I think the following must be done:
- rename private method `-_longPressTimerDidFire:` to `- longPressTimerDidFire:`
- squeeze the code within 100 columns

maybe also the point of the touch should be passed to the delegate (like the other method in the NIAttributedLabelDelegate protocol)?
