### PR TITLE
Autoadjust label text size for NIFormCells

### DIFF
--- a/src/models/src/NIFormCellCatalog.m
+++ b/src/models/src/NIFormCellCatalog.m
@@ -265,6 +265,7 @@ static const CGFloat kDatePickerTextFieldRightMargin = 5;
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
         [self.textLabel setAdjustsFontSizeToFitWidth:YES];
+        [self.textLabel setMinimumFontSize:10.0f];
     }
     return self;
 }
@@ -310,6 +311,7 @@ static const CGFloat kDatePickerTextFieldRightMargin = 5;
     _textField = [[UITextField alloc] init];
     [_textField setTag:self.element.elementID];
     [_textField setAdjustsFontSizeToFitWidth:YES];
+    [_textField setMinimumFontSize:10.0f];
     [_textField addTarget:self action:@selector(textFieldDidChangeValue) forControlEvents:UIControlEventAllEditingEvents];
     [self.contentView addSubview:_textField];
 


### PR DESCRIPTION
Not sure if you like that change, but in my app I use NISwitchFormElement for settings and the description of those settings is often longer than the available space ... so, there you go ;)
