### PR TITLE
NIAttributedLabel bug fix

### DIFF
--- a/examples/catalog/Catalog/LinksAttributedLabelViewController.m
+++ b/examples/catalog/Catalog/LinksAttributedLabelViewController.m
@@ -83,7 +83,7 @@
   @"\nSigned beneath the image: tenach.deviantart.com"
   
   // Japanese
-  @"\n\n\nこんにちは、ニンバス！これはBugテストです。";
+  @"\n\n\nこんにちは、ニンバス！これはテストです。";
 
   NSRange linkRange = [label.text rangeOfString:@"an artist's rendition of the planet"];
 

--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -727,11 +727,13 @@ static const CGFloat kTouchGutter = 22;
     CGFloat ascent = 0.0f;
     CGFloat descent = 0.0f;
     CGFloat leading = 0.0f;
+    
+    // Use of 'leading' doesn't properly highlight Japanese-character link.
     CGFloat width = (CGFloat)CTRunGetTypographicBounds(run,
                                                        CFRangeMake(0, 0),
                                                        &ascent,
                                                        &descent,
-                                                       &leading);
+                                                       NULL); //&leading);
     CGFloat height = ascent + descent;
 
     CGFloat xOffset = CTLineGetOffsetForStringIndex(line, CTRunGetStringRange(run).location, nil);


### PR DESCRIPTION
Hi, I found 2 minor bugs in NIAttributedLabel which doesn't handle link-highlighting correctly in special cases,
so I added few lines of code to fix it.

I also committed a bug code to demonstrate, so please check :)

(Please note that I'm new to CoreText so these fixes may be wrong)
