### PR TITLE
NIImageProcessing preserve source image orientation

### DIFF
--- a/src/networkimage/src/NIImageProcessing.m
+++ b/src/networkimage/src/NIImageProcessing.m
@@ -310,7 +310,7 @@
         if ([[UIImage class] respondsToSelector:@selector(imageWithCGImage:scale:orientation:)]) {
           resultImage = [UIImage imageWithCGImage: resultImageRef
                                             scale: screenScale
-                                      orientation: UIImageOrientationUp];
+                                      orientation: src.imageOrientation];
 
         } else {
           resultImage = [UIImage imageWithCGImage: resultImageRef];


### PR DESCRIPTION
I noticed when using NIImageProcessing to resize an image from the camera, it would return as the wrong orientation. By setting the resultImage orientation to the source image's orientation, this issue is fixed. 

There is some crucial orientation data saved in the UIImage imageOrientation property when dealing with images from the camera.
