### PR TITLE
Ensure photo zooming is set correctly after page reuse.

### DIFF
--- a/src/photos/src/NIPhotoAlbumScrollView.m
+++ b/src/photos/src/NIPhotoAlbumScrollView.m
@@ -99,14 +99,18 @@
     [page setImage:self.loadingImage photoSize:NIPhotoScrollViewPhotoSizeUnknown];
 
   } else {
+    BOOL updateImage = photoSize > page.photoSize;
+    if (updateImage) {
+      [page setImage:image photoSize:photoSize];
+    }
+
+    // Configure this after the image is set otherwise if the page's image isn't there
+	// e.g. (after prepareForReuse), zooming will always be disabled
     page.zoomingIsEnabled = ([self isZoomingEnabled]
                              && (NIPhotoScrollViewPhotoSizeOriginal == photoSize));
-    if (photoSize > page.photoSize) {
-      [page setImage:image photoSize:photoSize];
 
-      if (NIPhotoScrollViewPhotoSizeOriginal == photoSize) {
-        [self notifyDelegatePhotoDidLoadAtIndex:page.pageIndex];
-      }
+    if (updateImage && NIPhotoScrollViewPhotoSizeOriginal == photoSize) {
+      [self notifyDelegatePhotoDidLoadAtIndex:page.pageIndex];
     }
   }
 }


### PR DESCRIPTION
NIPhotoScrollView's setZoomingIsEnabled: checks whether an image is set
before allowing the zoomingIsEnabled property to affect its internal
scroll view's zoom.

This is usually fine whilst scrolling to the left of the album to get
the next pages, however when scrolling back and loading previous pages
whose images have been cleared due to prepareForReuse, the call to
setZoomingIsEnabled: is too early to have the intended effect.

This patch remedies this by setting the property only after any
potential image is set on the page.
