### PR TITLE
NIDatePickerFormElement doesn't display date set programatically

### DIFF
--- a/src/models/src/NIFormCellCatalog.m
+++ b/src/models/src/NIFormCellCatalog.m
@@ -743,6 +743,7 @@ static const CGFloat kDatePickerTextFieldRightMargin = 5;
   if ([super shouldUpdateCellWithObject:datePickerElement]) {
     self.textLabel.text = datePickerElement.labelText;
     self.datePicker.datePickerMode = datePickerElement.datePickerMode;
+    self.datePicker.date = datePickerElement.date;
     
     switch (self.datePicker.datePickerMode) {
       case UIDatePickerModeDate:


### PR DESCRIPTION
With this pull request you can set the date of a
NIDatePickerFormElement after it was initialized and it will display it
in the table cell.

Example:

```
[NIDatePickerFormElement datePickerElementWithID:AddFieldBirthday labelText:NSLocalizedString(@"Birthday", @"Birthday") date:[NSDate date]  datePickerMode:UIDatePickerModeDate];

...
[(NIDatePickerFormElement *)[_model elementWithID:AddFieldBirthday] setDate:person.birthday];
```
