### PR TITLE
Bugfix for bug introduced in a24f72c8f64b1a14a6d2ed460edb165451777707

### DIFF
--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -689,6 +689,7 @@ const CGFloat NIPagingScrollViewDefaultPageMargin = 10;
     _animatingToPageIndex = pageIndex;
     return NO;
   }
+  _isKillingAnimation = NO;
   _animatingToPageIndex = -1;
 
   CGPoint offset = [self frameForPageAtIndex:pageIndex].origin;


### PR DESCRIPTION
If you have a NIPagingScrollView, if you do reloadData, afterwards moveToPageAtIndex stops working until you scroll the view. This fixes that problem.
