### PR TITLE
[Bug fix]:NIImageProcessing - (void)setPathToNetworkImage:(NSString *)pathToNetworkImage forDisplaySize:(CGSize)displaySize contentMode:(UIViewContentMode)contentMode cropRect:(CGRect)cropRect Error

### DIFF
--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -395,7 +395,7 @@
          [self _didFailToLoadWithError:error];
        }];
         
-      [operation setDownloadProgressBlock:^(NSInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) {
+      [operation setDownloadProgressBlock:^(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) {
           if ([self.delegate respondsToSelector:@selector(networkImageView:readBytes:totalBytes:)]) {
               [self.delegate networkImageView:self readBytes:totalBytesRead totalBytes:totalBytesExpectedToRead];
           }


### PR DESCRIPTION
line 398:
In AFImageRequestOperation :
(void)setDownloadProgressBlock:(void (^)(**NSUInteger** bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))block 
