### PR TITLE
NIAttributedLabel: highlight for link drawn at incorrect y offset

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1247,7 +1247,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
         }
 
         CGRect highlightRect = [self _rectForRange:linkRange inLine:line lineOrigin:lineOrigins[i]];
-        highlightRect = CGRectMake(highlightRect.origin.x, highlightRect.origin.y - rect.origin.y, highlightRect.size.width, highlightRect.size.height);
+        highlightRect = CGRectOffset(highlightRect, 0, -rect.origin.y);
 
         if (!CGRectIsEmpty(highlightRect)) {
           CGFloat pi = (CGFloat)M_PI;


### PR DESCRIPTION
When using NIVerticalTextAlignmentMiddle (and probably NIVerticalTextAlignmentBottom as well) and tapping a detected link in NIAttributedLabel, the highlight rectangle is drawn at the incorrect y offset.

I changed the highlightrect to take the y offset into account, and this seems to resolve the issue.
