### PR TITLE
Added an additional case in the NetworkPhotoAlbums example to grab photos from the device's saved photos

### DIFF
--- a/examples/photos/NetworkPhotoAlbums/NetworkPhotoAlbum.xcodeproj/project.pbxproj
+++ b/examples/photos/NetworkPhotoAlbums/NetworkPhotoAlbum.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		66EAC64D13D28D9A00BDFF34 /* NICommonMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EAC64C13D28D9A00BDFF34 /* NICommonMetrics.m */; };
 		66EAC7DC13D2A77D00BDFF34 /* NimbusPhotos.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 66EAC7DB13D2A77D00BDFF34 /* NimbusPhotos.bundle */; };
 		66F27D5D145B7DF500AFCA08 /* NIViewRecycler.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F27D5C145B7DF500AFCA08 /* NIViewRecycler.m */; };
+		8B701B2B161DD2AB00AA3580 /* LocalPhotoAlbumViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B701B2A161DD2AB00AA3580 /* LocalPhotoAlbumViewController.m */; };
+		8B701B66161DD50B00AA3580 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B701B65161DD50B00AA3580 /* AssetsLibrary.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -227,6 +229,9 @@
 		66EAC7DB13D2A77D00BDFF34 /* NimbusPhotos.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = NimbusPhotos.bundle; path = ../../../src/photos/resources/NimbusPhotos.bundle; sourceTree = SOURCE_ROOT; };
 		66F27D5B145B7DF500AFCA08 /* NIViewRecycler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NIViewRecycler.h; path = ../../../src/core/src/NIViewRecycler.h; sourceTree = "<group>"; };
 		66F27D5C145B7DF500AFCA08 /* NIViewRecycler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NIViewRecycler.m; path = ../../../src/core/src/NIViewRecycler.m; sourceTree = "<group>"; };
+		8B701B29161DD2AB00AA3580 /* LocalPhotoAlbumViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LocalPhotoAlbumViewController.h; path = src/LocalPhotoAlbumViewController.h; sourceTree = "<group>"; };
+		8B701B2A161DD2AB00AA3580 /* LocalPhotoAlbumViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LocalPhotoAlbumViewController.m; path = src/LocalPhotoAlbumViewController.m; sourceTree = "<group>"; };
+		8B701B65161DD50B00AA3580 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -234,6 +239,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B701B66161DD50B00AA3580 /* AssetsLibrary.framework in Frameworks */,
 				1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */,
 				1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */,
 				288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */,
@@ -258,6 +264,7 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
+				8B701B65161DD50B00AA3580 /* AssetsLibrary.framework */,
 				66EAC47F13D2368100BDFF34 /* README.mdown */,
 				66EA058213C011D6004FFE1A /* NetworkPhotoAlbum_Prefix.pch */,
 				66EA057A13C011C0004FFE1A /* Source */,
@@ -292,6 +299,7 @@
 			children = (
 				6631671513D680A500FF0CBE /* NetworkPhotoAlbumViewController.h */,
 				6631671613D680A500FF0CBE /* NetworkPhotoAlbumViewController.m */,
+				8B701B28161DD27600AA3580 /* Local */,
 				6631680213D688FC00FF0CBE /* Dribbble */,
 				6631673813D6826600FF0CBE /* Facebook */,
 			);
@@ -531,6 +539,15 @@
 			name = Resources;
 			sourceTree = "<group>";
 		};
+		8B701B28161DD27600AA3580 /* Local */ = {
+			isa = PBXGroup;
+			children = (
+				8B701B29161DD2AB00AA3580 /* LocalPhotoAlbumViewController.h */,
+				8B701B2A161DD2AB00AA3580 /* LocalPhotoAlbumViewController.m */,
+			);
+			name = Local;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -658,6 +675,7 @@
 				66D2FE491594202500B2BEFD /* AFURLConnectionOperation.m in Sources */,
 				66D2FE4A1594202500B2BEFD /* AFXMLRequestOperation.m in Sources */,
 				66D2FE4B1594202500B2BEFD /* UIImageView+AFNetworking.m in Sources */,
+				8B701B2B161DD2AB00AA3580 /* LocalPhotoAlbumViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -676,7 +694,7 @@
 				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "resources/NetworkPhotoAlbum-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				PRODUCT_NAME = NetworkPhotoAlbum;
 				SDKROOT = iphoneos;
 			};
@@ -691,7 +709,7 @@
 				GCC_PREFIX_HEADER = src/NetworkPhotoAlbum_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "resources/NetworkPhotoAlbum-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				PRODUCT_NAME = NetworkPhotoAlbum;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/examples/photos/NetworkPhotoAlbums/README.mdown
+++ b/examples/photos/NetworkPhotoAlbums/README.mdown
@@ -1,3 +1,6 @@
+Update by: Brett Spurrier (brett.spurrier (at) gmail (dot) com)
+This fork add extends the NetworkPhotoAlbum example to include reading
+
 Network Photo Albums Sample Application
 =======================================
 

--- a/examples/photos/NetworkPhotoAlbums/src/AppDelegate.m
+++ b/examples/photos/NetworkPhotoAlbums/src/AppDelegate.m
@@ -38,7 +38,7 @@
 - (BOOL)              application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
-  [NIOverview applicationDidFinishLaunching];
+  //[NIOverview applicationDidFinishLaunching];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 
@@ -50,7 +50,7 @@
 
   [self.window makeKeyAndVisible];
 
-  [NIOverview addOverviewToWindow:self.window];
+  //[NIOverview addOverviewToWindow:self.window];
   
   return YES;
 }

--- a/examples/photos/NetworkPhotoAlbums/src/CatalogTableViewController.m
+++ b/examples/photos/NetworkPhotoAlbums/src/CatalogTableViewController.m
@@ -16,6 +16,7 @@
 
 #import "CatalogTableViewController.h"
 
+#import "LocalPhotoAlbumViewController.h"
 #import "FacebookPhotoAlbumViewController.h"
 #import "DribbblePhotoAlbumViewController.h"
 #import "AFNetworking.h"
@@ -34,6 +35,13 @@
 
     NSArray* tableContents =
     [NSArray arrayWithObjects:
+     @"Local Photos",
+     [NSDictionary dictionaryWithObjectsAndKeys:
+      [LocalPhotoAlbumViewController class], @"class",
+      @"Browse Device Photos", @"title",
+      @"/local", @"initWith",
+      nil],
+     
      @"Dribbble",
      [NSDictionary dictionaryWithObjectsAndKeys:
       [DribbblePhotoAlbumViewController class], @"class",

--- a/examples/photos/NetworkPhotoAlbums/src/LocalPhotoAlbumViewController.h
+++ b/examples/photos/NetworkPhotoAlbums/src/LocalPhotoAlbumViewController.h
@@ -1,0 +1,48 @@
+//
+// Copyright 2012 Brett Spurrier
+// Extended from DribblePhotoAlbumViewController (Copyright 2011 Jeff Verkoeyen)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "NetworkPhotoAlbumViewController.h"
+
+/**
+ * Shows the local photos on the device.
+ *
+ *      Minimum iOS SDK Version: 4.0
+ *      SDK Requirements: Blocks (4.0)
+ */
+@interface LocalPhotoAlbumViewController : NetworkPhotoAlbumViewController <
+NIPhotoAlbumScrollViewDataSource,
+NIPhotoScrubberViewDataSource,
+NIOperationDelegate
+> {
+@private
+  NSString* _apiPath;
+  
+  NSArray* _photoInformation;
+}
+
+/**
+ * The generic entry point used by the catalog view controller to initialize this controller.
+ */
+- (id)initWith:(id)object;
+
+@property (nonatomic, readwrite, copy) NSString* apiPath;
+
+
+@end

--- a/examples/photos/NetworkPhotoAlbums/src/NetworkPhotoAlbumViewController.h
+++ b/examples/photos/NetworkPhotoAlbums/src/NetworkPhotoAlbumViewController.h
@@ -101,4 +101,7 @@
                      photoSize: (NIPhotoScrollViewPhotoSize)photoSize
                     photoIndex: (NSInteger)photoIndex;
 
+- (void)requestImageFromAssetsLibrary:(NSString *)source
+                            photoSize:(NIPhotoScrollViewPhotoSize)photoSize
+                           photoIndex:(NSInteger)photoIndex;
 @end


### PR DESCRIPTION
This is my first pull request ever, so bear with me if it's not up to par. But I needed a use case to pull and scroll through photos from my devices saved photo roll, so this pull request includes a few additional methods made to the `NetworkPhotoAlbum` example to do just that. 

I don't own an iPad, so I'm merely hoping that everything translated well to the iPad format, but I can revisit it if need be.

Hope this helps someone out there, and I'm glad to finally be giving back to the nimbus community!
