### PR TITLE
[webcontroller] Add NIWebController::openHTMLString:baseURL:

### DIFF
--- a/src/webcontroller/src/NIWebController.h
+++ b/src/webcontroller/src/NIWebController.h
@@ -83,6 +83,7 @@
 
 - (void)openURL:(NSURL*)URL;
 - (void)openRequest:(NSURLRequest*)request;
+- (void)openHTMLString:(NSString*)htmlString baseURL:(NSURL*)baseUrl;
 
 @property (nonatomic, readwrite, assign, getter = isToolbarHidden) BOOL toolbarHidden;
 @property (nonatomic, readwrite, assign) UIColor* toolbarTintColor;
@@ -138,6 +139,15 @@
  *      @param request  A URL request identifying the location of the content to load.
  *
  *      @fn NIWebController::openRequest:
+ */
+
+/**
+ * Load the given request using UIWebView's loadHTMLString:baseURL:.
+ *
+ *      @param htmlString  The content for the main page.
+ *      @param baseUrl  The base URL for the content.
+ *
+ *      @fn NIWebController::openHTMLString:baseURL:
  */
 
 /** @name Accessing the Toolbar */

--- a/src/webcontroller/src/NIWebController.m
+++ b/src/webcontroller/src/NIWebController.m
@@ -485,6 +485,13 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)openHTMLString:(NSString*)htmlString baseURL:(NSURL*)baseUrl {
+	NIDASSERT([self isViewLoaded]);
+	[_webView loadHTMLString:htmlString baseURL:baseUrl];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setToolbarHidden:(BOOL)hidden {
   _toolbarHidden = hidden;
   if ([self isViewLoaded]) {


### PR DESCRIPTION
This pull requests adds the once missing method in `UIView` for loading content to `NIWebController`. It lets you open up a web page defined as a `NSString` containing HTML. It's a simple patch and there aren't any unit tests in the web controller package, I didn't make any changes there. The docs are updated.
