### PR TITLE
Fix for an incorrect assert in NIMutableTableViewModel

### DIFF
--- a/src/models/src/NIMutableTableViewModel.m
+++ b/src/models/src/NIMutableTableViewModel.m
@@ -196,7 +196,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (NSMutableArray *)mutableRows {
-  NIDASSERT([self.rows isKindOfClass:[NSMutableArray class]]);
+  NIDASSERT([self.rows isKindOfClass:[NSMutableArray class]] || nil == self.rows);
+    
+  self.rows = nil == self.rows ? [NSMutableArray array] : self.rows;
   return (NSMutableArray *)self.rows;
 }
 


### PR DESCRIPTION
If a mutable table view model is created with an empty section, then when objects are added to that section later, the assert in the method mutableRows fires.
