### PR TITLE
[photos] Exposes `doubleTapGestureRecognizer` of `NIPhotoScrollView` as a property.

### DIFF
--- a/src/photos/src/NIPhotoScrollView.h
+++ b/src/photos/src/NIPhotoScrollView.h
@@ -68,6 +68,7 @@
 
 @property (nonatomic, readwrite, assign) NSInteger pageIndex;
 @property (nonatomic, readwrite, assign) CGSize photoDimensions;
+@property (nonatomic, readonly, NI_STRONG) UITapGestureRecognizer* doubleTapGestureRecognizer;
 
 @end
 
@@ -171,4 +172,12 @@
  * CGSizeZero is used to signify an unknown final photo dimension.
  *
  *      @fn NIPhotoScrollView::photoDimensions
+ */
+
+/**
+ * The gesture recognizer for double-tapping zooms in and out of the image.
+ *
+ * This is used mainly for setting up dependencies between gesture recognizers.
+ *
+ *      @fn NIPhotoScrollView::doubleTapGestureRecognizer
  */

--- a/src/photos/src/NIPhotoScrollView.m
+++ b/src/photos/src/NIPhotoScrollView.m
@@ -102,6 +102,7 @@
 @synthesize doubleTapToZoomIsEnabled = _doubleTapToZoomIsEnabled;
 @synthesize maximumScale = _maximumScale;
 @synthesize loading = _loading;
+@synthesize doubleTapGestureRecognizer = _doubleTapGestureRecognizer;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently, `NIPhotoScrollView` uses its delegate to allow developer to establish dependency with double-tapping zooms in and out of the image gesture.

There is a better way, available since iOS 3.2, that is by setting up the dependency between gesture recognisers through `UIGestureRecognizer`'s `requireGestureRecognizerToFail:` method.

Exposing `doubleTapGestureRecognizer` as a property allow developer to setup such dependency as they needs.
