### PR TITLE
Add simulate low memory warning in Overview

### DIFF
--- a/src/overview/src/NIDeviceInfo.h
+++ b/src/overview/src/NIDeviceInfo.h
@@ -62,6 +62,12 @@ NSString* NIStringFromBytes(unsigned long long bytes);
  */
 + (unsigned long long)bytesOfTotalMemory;
 
+/**
+ * Simulate low memory warning
+ *
+ * Don't use this in production because it uses private API
+ */
++ (void)simulateLowMemoryWarning;
 
 #pragma mark Disk Space /** @name Disk Space */
 
@@ -119,5 +125,6 @@ NSString* NIStringFromBytes(unsigned long long bytes);
  * Stop using the cache for the device info methods.
  */
 + (void)endCachedDeviceInfo;
+
 
 @end

--- a/src/overview/src/NIDeviceInfo.m
+++ b/src/overview/src/NIDeviceInfo.m
@@ -134,6 +134,24 @@ NSString* NIStringFromBytes(unsigned long long bytes) {
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
++ (void)simulateLowMemoryWarning
+{
+  SEL memoryWarningSel =  NSSelectorFromString(@"_performMemoryWarning");
+  if ([[UIApplication sharedApplication] respondsToSelector:memoryWarningSel]) {
+    NIDINFO(@"Simulate low memory warning");
+    // Supress the warning. -Wundeclared-selector was used while ARC is enabled.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [[UIApplication sharedApplication] performSelector:memoryWarningSel];
+#pragma clang diagnostic pop
+  } else {
+    // UIApplication no loger responds to _performMemoryWarning
+    exit(1);
+  }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 + (unsigned long long)bytesOfFreeDiskSpace {
   if (!sIsCaching && ![self updateFileSystemAttributes]) {
     return 0;

--- a/src/overview/src/NIOverviewPageView.m
+++ b/src/overview/src/NIOverviewPageView.m
@@ -265,6 +265,11 @@ static const CGFloat kGraphRightMargin = 5;
     self.pageTitle = NSLocalizedString(@"Memory", @"Overview Page Title: Memory");
     
     self.graphView.dataSource = self;
+
+    UITapGestureRecognizer* tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTap:)];
+    // We still want to be able to drag the pages.
+    tap.cancelsTouchesInView = NO;
+    [self addGestureRecognizer:tap];
   }
   return self;
 }
@@ -285,6 +290,13 @@ static const CGFloat kGraphRightMargin = 5;
   [NIDeviceInfo endCachedDeviceInfo];
 
   [self setNeedsLayout];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)didTap:(UIGestureRecognizer *)gesture {
+  // Simulate low memory warning while tapping on NIOverviewMemoryPageView
+  [NIDeviceInfo simulateLowMemoryWarning];
 }
 
 


### PR DESCRIPTION
Add + (void)simulateLowMemoryWarning in NIDeviceInfo.
Simulate low memory warning when tapping on NIOverviewMemoryPageView.
