### PR TITLE
NIDrawRectBlockObject: Transparent background

### DIFF
--- a/src/models/src/NICellCatalog.m
+++ b/src/models/src/NICellCatalog.m
@@ -195,6 +195,14 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (id)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        self.backgroundColor = [UIColor clearColor];
+    }
+    return self;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)drawRect:(CGRect)rect {
   if (nil != self.block) {
     self.block(rect, self.object, self.cell);


### PR DESCRIPTION
Changed background color of NIDrawRectBlockView to clear.
This allows the cell to be used in grouped tableviews. At the moment the background color is black, resulting in black corners for custom drawn grouped tableview cells.
