### PR TITLE
[attributedlabel] Allow linkColor to be ignored when nil.

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1111,7 +1111,9 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)_applyLinkStyleWithResults:(NSArray *)results toAttributedString:(NSMutableAttributedString *)attributedString {
   for (NSTextCheckingResult* result in results) {
-    [attributedString setTextColor:self.linkColor range:result.range];
+    if (self.linkColor) {
+      [attributedString setTextColor:self.linkColor range:result.range];
+    }
 
     // We add a no-op attribute in order to force a run to exist for each link. Otherwise the
     // runCount will be one in this line, causing the entire line to be highlighted rather than


### PR DESCRIPTION
I have recently encountered a project where the links in attributed label have to be styled in different color. However, it seems that if it is a link, the color that is specified through `setLinkColor:` takes precedence over `setTextColor:range:`.

In the local copy of nimbus in that project, a change was made to ignore `linkColor` if it is `nil`. Therefore, one could specify different colors of links as follows:

``` objective-c
NIAttributedLabel *labelView = [[NIAttributedLabel alloc] init];
[labelView setLinkColor:nil];

[labelView setText:@"Hello Nimbus!"];
[labelView addLink:[NSURL URLWithString:@"http://example.com/"] range:NSMakeRange(0, 5)];
[labelView setTextColor:[UIColor redColor] range:NSMakeRange(0, 5)];
[labelView addLink:[NSURL URLWithString:@"http://nimbuskit.info/"] range:NSMakeRange(6, 6)];
[labelView setTextColor:[UIColor brownColor] range:NSMakeRange(6, 6)];
```

I am not sure if it is useful to others, nor if there is another better way of doing this (a flag for global ignore of link styles perhaps?). Please kindly review and see if it is appropriate. Thanks!
