### PR TITLE
Adding UIKit header to the NIImageUtilities

### DIFF
--- a/src/core/src/NIImageUtilities.h
+++ b/src/core/src/NIImageUtilities.h
@@ -15,6 +15,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #if defined __cplusplus
 extern "C" {


### PR DESCRIPTION
Allows this to compile in cases where we don't use prefix headers.
