### PR TITLE
[overview] Fix overview height boot on landscape

### DIFF
--- a/src/overview/src/NIOverview.m
+++ b/src/overview/src/NIOverview.m
@@ -162,9 +162,12 @@ void NIOverviewLogMethod(const char* message, unsigned length, BOOL withSyslogBa
   sOverviewView.center = CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame));
 
   CGRect bounds = sOverviewView.bounds;
-  bounds.size.width = (UIInterfaceOrientationIsLandscape(NIInterfaceOrientation())
-                       ? frame.size.height
-                       : frame.size.width);
+  if (UIInterfaceOrientationIsLandscape(NIInterfaceOrientation())) {
+    bounds.size.width = frame.size.height;
+    bounds.size.height = frame.size.width;
+  } else {
+    bounds.size = frame.size;
+  }
   sOverviewView.bounds = bounds;
 
   // Get ready to fade the overview back in.


### PR DESCRIPTION
Hi.

I want to use overview with iPad landscape mode.
But now overview size is too height when it boot on landscape with iPad and iOS6.

So I try to fix.

Thanks,
