### PR TITLE
NITableViewSystem & NITableViewDelegate

### DIFF
--- a/examples/catalog/Catalog/CatalogViewController.m
+++ b/examples/catalog/Catalog/CatalogViewController.m
@@ -66,6 +66,7 @@
 #import "BlockCellsViewController.h"
 #import "SnapshotRotationTableViewController.h"
 #import "MutableTableModelViewController.h"
+#import "TableSystemViewController.h"
 
 // Web Controller
 #import "ExtraActionsWebViewController.h"
@@ -361,6 +362,11 @@
                                    subtitle:@"Mutating table view models"]
               navigationBlock:
       NIPushControllerAction([MutableTableModelViewController class])],
+     [_actions attachToObject:
+      [NISubtitleCellObject objectWithTitle:@"TableViewSystem"
+                                   subtitle:@"Simplifying table view creation"]
+              navigationBlock:
+      NIPushControllerAction([TableSystemViewController class])],
 
      @"Web Controller",
      [_actions attachToObject:

--- a/examples/catalog/Catalog/TableSystemViewController.h
+++ b/examples/catalog/Catalog/TableSystemViewController.h
@@ -1,0 +1,24 @@
+//
+// Copyright 2013 Jared Egan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@interface TableSystemViewController : UIViewController {
+
+}
+
+@end

--- a/examples/catalog/Catalog/TableSystemViewController.m
+++ b/examples/catalog/Catalog/TableSystemViewController.m
@@ -1,0 +1,113 @@
+//
+// Copyright 2013 Jared Egan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "TableSystemViewController.h"
+#import "NimbusModels.h"
+#import "NimbusCore.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@interface TableSystemViewController() <NITableViewSystemDelegate,
+UIScrollViewDelegate>
+
+@property (nonatomic, strong) NITableViewSystem *tableSystem;
+@property (nonatomic, strong) UILabel *scrollInfoLabel;
+@property (nonatomic, strong) NISubtitleCellObject *scrollInfoTableObject;
+
+@end
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@implementation TableSystemViewController
+
+#pragma mark -
+#pragma mark Init
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (id)init {
+  self = [super init];
+	if (self) {
+    self.title = @"TableViewSystem";
+	}
+	
+	return self;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)dealloc {
+
+}
+
+#pragma mark -
+#pragma mark UIViewController
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  // Table View
+  self.tableSystem = [NITableViewSystem tableSystemWithFrame:self.view.bounds
+                                                       style:UITableViewStyleGrouped
+                                                    delegate:self];
+  [self.view addSubview:self.tableSystem.tableView];
+
+  // Table datasource
+  NSMutableArray *tableContents = [NSMutableArray array];
+
+  [tableContents addObject:[NITitleCellObject objectWithTitle:@"Row 1"]];
+  [tableContents addObject:[NITitleCellObject objectWithTitle:@"Row 2"]];
+
+  self.scrollInfoTableObject = [NISubtitleCellObject objectWithTitle:@"Row 3" subtitle:@"Subtitle"];
+
+  [tableContents addObject:self.scrollInfoTableObject];
+
+  [self.tableSystem setDataSourceWithListArray:tableContents];
+
+  // Scroll info label (to demonstrate UIScrollViewDelegate messages
+  self.scrollInfoLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 10, self.view.bounds.size.width, 44)];
+  self.scrollInfoLabel.textAlignment = NSTextAlignmentCenter;
+  self.scrollInfoLabel.backgroundColor = [UIColor clearColor];
+  [self.view addSubview:self.scrollInfoLabel];
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+
+  self.tableSystem.tableView.frame = self.view.bounds;
+  self.scrollInfoLabel.frame = CGRectMake(self.scrollInfoLabel.frame.origin.x,
+                                          self.view.bounds.size.height - self.scrollInfoLabel.frame.size.height - 10,
+                                          self.scrollInfoLabel.frame.size.width,
+                                          self.scrollInfoLabel.frame.size.height);
+}
+
+#pragma mark -
+#pragma mark NITableViewSystemDelegate
+- (void)tableSystem:(NITableViewSystem *)tableSystem didSelectObject:(id)object
+        atIndexPath:(NSIndexPath *)indexPath {
+  NSLog(@"Object was selected: %@ at indexPath: %@", object, indexPath);
+  
+}
+
+- (void)tableSystem:(NITableViewSystem *)tableSystem didAssignCell:(id)object toTableItem:(id)tableItem
+        atIndexPath:(NSIndexPath *)indexPath {
+
+}
+
+#pragma mark -
+#pragma mark UIScrollViewDelegate
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+
+  self.scrollInfoLabel.text = [NSString stringWithFormat:@"Scroll view offset: %f, %f", scrollView.contentOffset.x, scrollView.contentOffset.y];
+}
+
+@end
+
+

--- a/examples/catalog/NimbusCatalog.xcodeproj/project.pbxproj
+++ b/examples/catalog/NimbusCatalog.xcodeproj/project.pbxproj
@@ -122,6 +122,9 @@
 		66D2FDD81593F17800B2BEFD /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 66D2FDCC1593F17800B2BEFD /* AFURLConnectionOperation.m */; };
 		66D2FDD91593F17800B2BEFD /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 66D2FDCE1593F17800B2BEFD /* AFXMLRequestOperation.m */; };
 		66D2FDDA1593F17800B2BEFD /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 66D2FDD01593F17800B2BEFD /* UIImageView+AFNetworking.m */; };
+		7F6128AF16E2F8C800C36DF7 /* TableSystemViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F6128AE16E2F8C800C36DF7 /* TableSystemViewController.m */; };
+		7FE1B76C16E2F76C005B62A3 /* NITableViewSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FE1B76B16E2F76C005B62A3 /* NITableViewSystem.m */; };
+		7FE1B77016E2F77A005B62A3 /* NITableViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FE1B76F16E2F77A005B62A3 /* NITableViewDelegate.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -364,6 +367,12 @@
 		66D2FDCE1593F17800B2BEFD /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
 		66D2FDCF1593F17800B2BEFD /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
 		66D2FDD01593F17800B2BEFD /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		7F6128AD16E2F8C800C36DF7 /* TableSystemViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TableSystemViewController.h; sourceTree = "<group>"; };
+		7F6128AE16E2F8C800C36DF7 /* TableSystemViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = TableSystemViewController.m; sourceTree = "<group>"; tabWidth = 2; };
+		7FE1B76A16E2F76C005B62A3 /* NITableViewSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NITableViewSystem.h; path = ../../src/models/src/NITableViewSystem.h; sourceTree = "<group>"; };
+		7FE1B76B16E2F76C005B62A3 /* NITableViewSystem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NITableViewSystem.m; path = ../../src/models/src/NITableViewSystem.m; sourceTree = "<group>"; };
+		7FE1B76E16E2F77A005B62A3 /* NITableViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NITableViewDelegate.h; path = ../../src/models/src/NITableViewDelegate.h; sourceTree = "<group>"; };
+		7FE1B76F16E2F77A005B62A3 /* NITableViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NITableViewDelegate.m; path = ../../src/models/src/NITableViewDelegate.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -455,6 +464,8 @@
 				6613335D15D3A66B00369333 /* SnapshotRotationTableViewController.m */,
 				66D2E54D15D9616500281511 /* MutableTableModelViewController.h */,
 				66D2E54E15D9616500281511 /* MutableTableModelViewController.m */,
+				7F6128AD16E2F8C800C36DF7 /* TableSystemViewController.h */,
+				7F6128AE16E2F8C800C36DF7 /* TableSystemViewController.m */,
 			);
 			name = "Table Models";
 			sourceTree = "<group>";
@@ -628,12 +639,16 @@
 				6693C221158A81DD00950D42 /* NIRadioGroupController.m */,
 				6693C222158A81DD00950D42 /* NITableViewActions.h */,
 				6693C223158A81DD00950D42 /* NITableViewActions.m */,
+				7FE1B76E16E2F77A005B62A3 /* NITableViewDelegate.h */,
+				7FE1B76F16E2F77A005B62A3 /* NITableViewDelegate.m */,
 				6693C224158A81DD00950D42 /* NITableViewModel.h */,
 				6693C225158A81DD00950D42 /* NITableViewModel.m */,
 				6693C226158A81DD00950D42 /* NITableViewModel+Private.h */,
 				66D2E54815D9613700281511 /* NIMutableTableViewModel.h */,
 				66D2E54915D9613800281511 /* NIMutableTableViewModel.m */,
 				66D2E54A15D9613800281511 /* NIMutableTableViewModel+Private.h */,
+				7FE1B76A16E2F76C005B62A3 /* NITableViewSystem.h */,
+				7FE1B76B16E2F76C005B62A3 /* NITableViewSystem.m */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -1001,6 +1016,9 @@
 				66D2E54B15D9613800281511 /* NIMutableTableViewModel.m in Sources */,
 				66D2E54F15D9616500281511 /* MutableTableModelViewController.m in Sources */,
 				3616212C16812222002A9078 /* AlignmentAttributedLabelViewController.m in Sources */,
+				7FE1B76C16E2F76C005B62A3 /* NITableViewSystem.m in Sources */,
+				7FE1B77016E2F77A005B62A3 /* NITableViewDelegate.m in Sources */,
+				7F6128AF16E2F8C800C36DF7 /* TableSystemViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/Nimbus.xcodeproj/project.pbxproj
+++ b/src/Nimbus.xcodeproj/project.pbxproj
@@ -347,6 +347,12 @@
 		66FE7D6B13FB83620061B987 /* NimbusModels.h in Headers */ = {isa = PBXBuildFile; fileRef = 66FE7D6413FB83620061B987 /* NimbusModels.h */; };
 		66FE7D6C13FB83620061B987 /* NITableViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 66FE7D6513FB83620061B987 /* NITableViewModel.h */; };
 		66FE7D6D13FB83620061B987 /* NITableViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 66FE7D6613FB83620061B987 /* NITableViewModel.m */; };
+		7FE1B74416DF1A3B005B62A3 /* NITableViewSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FE1B74216DF1A3B005B62A3 /* NITableViewSystem.h */; };
+		7FE1B74516DF1A3B005B62A3 /* NITableViewSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FE1B74316DF1A3B005B62A3 /* NITableViewSystem.m */; };
+		7FE1B74616DF1A3B005B62A3 /* NITableViewSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FE1B74316DF1A3B005B62A3 /* NITableViewSystem.m */; };
+		7FE1B74916DF1D53005B62A3 /* NITableViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FE1B74716DF1D53005B62A3 /* NITableViewDelegate.h */; };
+		7FE1B74A16DF1D53005B62A3 /* NITableViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FE1B74816DF1D53005B62A3 /* NITableViewDelegate.m */; };
+		7FE1B74B16DF1D53005B62A3 /* NITableViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FE1B74816DF1D53005B62A3 /* NITableViewDelegate.m */; };
 		C743F6EA16D2652F00A933B7 /* NIUserInterfaceString.h in Headers */ = {isa = PBXBuildFile; fileRef = C743F6E816D2652F00A933B7 /* NIUserInterfaceString.h */; };
 		C743F6EB16D2652F00A933B7 /* NIUserInterfaceString.m in Sources */ = {isa = PBXBuildFile; fileRef = C743F6E916D2652F00A933B7 /* NIUserInterfaceString.m */; };
 		C7A8791D16D7348700A0C23F /* NITextField+NIStyleable.h in Headers */ = {isa = PBXBuildFile; fileRef = C7A8791B16D7348700A0C23F /* NITextField+NIStyleable.h */; };
@@ -981,6 +987,10 @@
 		66FE7D6513FB83620061B987 /* NITableViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NITableViewModel.h; sourceTree = "<group>"; };
 		66FE7D6613FB83620061B987 /* NITableViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NITableViewModel.m; sourceTree = "<group>"; };
 		66FE7D6813FB83620061B987 /* NimbusModelsTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "NimbusModelsTests-Info.plist"; sourceTree = "<group>"; };
+		7FE1B74216DF1A3B005B62A3 /* NITableViewSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NITableViewSystem.h; sourceTree = "<group>"; };
+		7FE1B74316DF1A3B005B62A3 /* NITableViewSystem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NITableViewSystem.m; sourceTree = "<group>"; };
+		7FE1B74716DF1D53005B62A3 /* NITableViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NITableViewDelegate.h; sourceTree = "<group>"; };
+		7FE1B74816DF1D53005B62A3 /* NITableViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NITableViewDelegate.m; sourceTree = "<group>"; };
 		C743F6E816D2652F00A933B7 /* NIUserInterfaceString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NIUserInterfaceString.h; path = css/src/NIUserInterfaceString.h; sourceTree = SOURCE_ROOT; };
 		C743F6E916D2652F00A933B7 /* NIUserInterfaceString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NIUserInterfaceString.m; path = css/src/NIUserInterfaceString.m; sourceTree = SOURCE_ROOT; };
 		C7A8791B16D7348700A0C23F /* NITextField+NIStyleable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NITextField+NIStyleable.h"; path = "css/src/NITextField+NIStyleable.h"; sourceTree = SOURCE_ROOT; };
@@ -2045,6 +2055,10 @@
 				667DD36A156D78980045ABBB /* NIRadioGroupController.m */,
 				66416179156B516E0018AC1C /* NITableViewActions.h */,
 				6641617A156B516E0018AC1C /* NITableViewActions.m */,
+				7FE1B74716DF1D53005B62A3 /* NITableViewDelegate.h */,
+				7FE1B74816DF1D53005B62A3 /* NITableViewDelegate.m */,
+				7FE1B74216DF1A3B005B62A3 /* NITableViewSystem.h */,
+				7FE1B74316DF1A3B005B62A3 /* NITableViewSystem.m */,
 			);
 			name = src;
 			path = models/src;
@@ -2191,6 +2205,8 @@
 				66B6710715AA820700FE4AE8 /* NICellBackgrounds.h in Headers */,
 				66D2E53F15D9432000281511 /* NIMutableTableViewModel.h in Headers */,
 				66D2E54315D9438D00281511 /* NIMutableTableViewModel+Private.h in Headers */,
+				7FE1B74416DF1A3B005B62A3 /* NITableViewSystem.h in Headers */,
+				7FE1B74916DF1D53005B62A3 /* NITableViewDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3489,6 +3505,8 @@
 				667DD36C156D78980045ABBB /* NIRadioGroupController.m in Sources */,
 				66B6710815AA820700FE4AE8 /* NICellBackgrounds.m in Sources */,
 				66D2E54015D9432000281511 /* NIMutableTableViewModel.m in Sources */,
+				7FE1B74516DF1A3B005B62A3 /* NITableViewSystem.m in Sources */,
+				7FE1B74A16DF1D53005B62A3 /* NITableViewDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3499,6 +3517,8 @@
 				6623EB6D1402ECE400E0E61A /* NITableViewModelTests.m in Sources */,
 				6672DAB515B87E4B00DFE81F /* NICellFactoryTests.m in Sources */,
 				66D2E54715D9503100281511 /* NIMutableTableViewModelTests.m in Sources */,
+				7FE1B74616DF1A3B005B62A3 /* NITableViewSystem.m in Sources */,
+				7FE1B74B16DF1D53005B62A3 /* NITableViewDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/models/src/NITableViewDelegate.h
+++ b/src/models/src/NITableViewDelegate.h
@@ -1,0 +1,32 @@
+//
+//  NITableViewDelegate.h
+//  Nimbus
+//
+//  Created by Jared Egan on 2/28/13.
+//  Copyright 2013 Jeff Verkoeyen. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "NITableViewSystem.h"
+
+@class NITableViewModel;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@interface NITableViewDelegate : NSObject <UITableViewDelegate,
+UIScrollViewDelegate> {
+
+}
+
+@property (nonatomic, strong) NITableViewModel *dataSource;
+
+@property (nonatomic, unsafe_unretained) NITableViewSystem *tableSystem;
+@property (nonatomic, unsafe_unretained) id<NITableViewSystemDelegate, UIScrollViewDelegate> delegate;
+
+- (id)initWithDataSource:(NITableViewModel *)dataSource;
+- (id)initWithDataSource:(NITableViewModel *)dataSource
+                delegate:(id<NITableViewSystemDelegate,UIScrollViewDelegate>)delegate;
+
+@end

--- a/src/models/src/NITableViewDelegate.m
+++ b/src/models/src/NITableViewDelegate.m
@@ -1,0 +1,217 @@
+//
+//  NITableViewDelegate.m
+//  Nimbus
+//
+//  Created by Jared Egan on 2/28/13.
+//  Copyright 2013 Jeff Verkoeyen. All rights reserved.
+//
+
+#import "NITableViewDelegate.h"
+
+#import "NimbusCore.h"
+
+#import "NICellFactory.h"
+#import "NITableViewSystem.h"
+
+#import "objc/runtime.h"
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@interface NITableViewDelegate()
+
+@end
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@implementation NITableViewDelegate
+
+#pragma mark -
+#pragma mark Init & Factory
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (id)initWithDataSource:(NITableViewModel *)dataSource {
+	if ((self = [super init])) {
+        self.dataSource = dataSource;
+	}
+
+	return self;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (id)initWithDataSource:(NITableViewModel *)dataSource
+                delegate:(id<NITableViewSystemDelegate,UIScrollViewDelegate>)delegate {
+	if ((self = [super init])) {
+        self.dataSource = dataSource;
+        self.delegate = delegate;
+	}
+
+	return self;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)dealloc {
+    self.delegate = nil;
+    self.tableSystem = nil;
+}
+
+#pragma mark -
+#pragma mark UITableViewDelegate
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+
+
+    if ([_delegate conformsToProtocol:@protocol(NITableViewSystemDelegate)]) {
+        id object = [self.dataSource objectAtIndexPath:indexPath];
+
+        if (object != nil) {
+            if ([_delegate respondsToSelector:@selector(tableSystem:didSelectObject:atIndexPath:)]) {
+                [_delegate tableSystem:self.tableSystem didSelectObject:object atIndexPath:indexPath];
+            }
+
+            /*
+            if ([object isKindOfClass:[KBTableItem class]]) {
+                KBTableItem *item = (KBTableItem *)object;
+
+                if (item.selectionBlock) {
+                    item.selectionBlock(item, indexPath);
+                }
+
+                if (item.delegate != nil && item.selector != nil) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+
+                    [item.delegate performSelector:item.selector withObject:item];
+#pragma clang diagnostic pop
+                }
+            }
+             */
+        }
+    }
+
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    id object = [self.dataSource objectAtIndexPath:indexPath];
+
+    if ([object conformsToProtocol:@protocol(NICellObject)]) {
+        Class cls = [(id<NICellObject>)object cellClass];
+        if ([cls conformsToProtocol:@protocol(NICell)]) {
+            Method method = class_getClassMethod(cls, @selector(heightForObject:atIndexPath:tableView:));
+
+            if (method != NULL) {
+                return [cls heightForObject:object
+                                atIndexPath:indexPath
+                                  tableView:tableView];
+            }
+        }
+    }
+
+    // Default option
+    return tableView.rowHeight;
+}
+
+#pragma mark -
+#pragma mark UIScrollViewDelegate
+// Forward all scrolling delegate messages to our delegate
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidScroll:)]) {
+        [self.delegate scrollViewDidScroll:scrollView];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewDidZoom:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidZoom:)]) {
+        [self.delegate scrollViewDidZoom:scrollView];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(scrollViewWillBeginDragging:)]) {
+        [self.delegate scrollViewWillBeginDragging:scrollView];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
+    if ([self.delegate respondsToSelector:@selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)]) {
+        [self.delegate scrollViewWillEndDragging:scrollView withVelocity:velocity targetContentOffset:targetContentOffset];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)]) {
+        [self.delegate scrollViewDidEndDragging:scrollView willDecelerate:decelerate];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewWillBeginDecelerating:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(scrollViewWillBeginDecelerating:)]) {
+        [self.delegate scrollViewWillBeginDecelerating:scrollView];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)]) {
+        [self.delegate scrollViewDidEndDecelerating:scrollView];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)]) {
+        [self.delegate scrollViewDidEndScrollingAnimation:scrollView];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(viewForZoomingInScrollView:)]) {
+        return [self.delegate viewForZoomingInScrollView:scrollView];
+    }
+
+    return nil;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(UIView *)view {
+    if ([self.delegate respondsToSelector:@selector(scrollViewWillBeginZooming:withView:)]) {
+        [self.delegate scrollViewWillBeginZooming:scrollView withView:view];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(UIView *)view atScale:(float)scale {
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidEndZooming:withView:atScale:)]) {
+        [self.delegate scrollViewDidEndZooming:scrollView withView:view atScale:scale];
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(scrollViewShouldScrollToTop:)]) {
+        return [self.delegate scrollViewShouldScrollToTop:scrollView];
+    }
+
+    // return a yes if you want to scroll to the top. if not defined, assumes YES
+    return YES;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewDidScrollToTop:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidScrollToTop:)]) {
+        [self.delegate scrollViewDidScrollToTop:scrollView];
+    }
+}
+
+@end

--- a/src/models/src/NITableViewSystem.h
+++ b/src/models/src/NITableViewSystem.h
@@ -37,7 +37,7 @@
 @optional
 - (void)tableSystem:(NITableViewSystem *)tableSystem didSelectObject:(id)object
         atIndexPath:(NSIndexPath *)indexPath;
-- (void)tableSystem:(NITableViewSystem *)tableSystem didAssignCell:(id)object toTableItem: (id)tableItem
+- (void)tableSystem:(NITableViewSystem *)tableSystem didAssignCell:(id)object toTableItem:(id)tableItem
 		atIndexPath:(NSIndexPath *)indexPath;
 @end
 

--- a/src/models/src/NITableViewSystem.h
+++ b/src/models/src/NITableViewSystem.h
@@ -54,7 +54,7 @@
 @property (nonatomic, strong) NITableViewModel *dataSource;
 @property (nonatomic, strong) NICellFactory *cellFactory;
 @property (nonatomic, strong) NITableViewDelegate *tableViewDelegate;
-@property (nonatomic, unsafe_unretained) id<NITableViewSystemDelegate, UIScrollViewDelegate> delegate;
+@property (nonatomic, weak) id<NITableViewSystemDelegate, UIScrollViewDelegate> delegate;
 
 + (id)tableSystemWithFrame:(CGRect)frame style:(UITableViewStyle)tableStyle delegate:(id<NITableViewSystemDelegate, UIScrollViewDelegate>)delegate;
 

--- a/src/models/src/NITableViewSystem.h
+++ b/src/models/src/NITableViewSystem.h
@@ -23,6 +23,7 @@
 
 @class NITableViewDelegate;
 @class NITableViewSystem;
+@class NICellFactory;
 
 /**
  * NITableViewSystemDelegates receive messages from the tableViewDelegate, including:
@@ -51,10 +52,11 @@
 
 // Data & Logic
 @property (nonatomic, strong) NITableViewModel *dataSource;
+@property (nonatomic, strong) NICellFactory *cellFactory;
 @property (nonatomic, strong) NITableViewDelegate *tableViewDelegate;
 @property (nonatomic, unsafe_unretained) id<NITableViewSystemDelegate, UIScrollViewDelegate> delegate;
 
-+ (NITableViewSystem *)tableSystemWithFrame:(CGRect)frame style:(UITableViewStyle)tableStyle delegate:(id<NITableViewSystemDelegate, UIScrollViewDelegate>)delegate;
++ (id)tableSystemWithFrame:(CGRect)frame style:(UITableViewStyle)tableStyle delegate:(id<NITableViewSystemDelegate, UIScrollViewDelegate>)delegate;
 
 /**
  *  A convenience method. Sets the datasource and reloads _tableView if specified.
@@ -67,6 +69,10 @@
 - (void)setDataSourceWithListArray:(NSArray *)listArray;
 - (void)setDataSourceWithListArray:(NSArray *)listArray reloadTableView:(BOOL)reloadTableView;
 
+/**
+ *  Returns a UITableView with the given frame. Subclasses can return table view preconfigured with more custom view tweaks.
+ */
+- (UITableView *)createTableViewWithFrame:(CGRect)frame withStyle:(UITableViewStyle)tableStyle;
 
 - (NSIndexPath *)indexPathForTableItem:(id)object;
 

--- a/src/models/src/NITableViewSystem.h
+++ b/src/models/src/NITableViewSystem.h
@@ -1,0 +1,92 @@
+//
+// Copyright 2012 Jared Egan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "NimbusCore.h"
+
+#import "NITableViewModel.h"
+
+@class NITableViewDelegate;
+@class NITableViewSystem;
+
+/**
+ * NITableViewSystemDelegates receive messages from the tableViewDelegate, including:
+ * - table row selection
+ * - Forwarding some UIScrollViewDelegate messages, so UIViewControllers can do neat things.
+ */
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@protocol NITableViewSystemDelegate <NSObject>
+
+@optional
+- (void)tableSystem:(NITableViewSystem *)tableSystem didSelectObject:(id)object
+        atIndexPath:(NSIndexPath *)indexPath;
+- (void)tableSystem:(NITableViewSystem *)tableSystem didAssignCell:(id)object toTableItem: (id)tableItem
+		atIndexPath:(NSIndexPath *)indexPath;
+@end
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@interface NITableViewSystem : NSObject <NITableViewModelDelegate> {
+
+}
+
+// UI
+@property (nonatomic, readonly) UITableView *tableView;
+
+// Data & Logic
+@property (nonatomic, strong) NITableViewModel *dataSource;
+@property (nonatomic, strong) NITableViewDelegate *tableViewDelegate;
+@property (nonatomic, unsafe_unretained) id<NITableViewSystemDelegate, UIScrollViewDelegate> delegate;
+
++ (NITableViewSystem *)tableSystemWithFrame:(CGRect)frame style:(UITableViewStyle)tableStyle delegate:(id<NITableViewSystemDelegate, UIScrollViewDelegate>)delegate;
+
+/**
+ *  A convenience method. Sets the datasource and reloads _tableView if specified.
+ */
+- (void)setDataSource:(NITableViewModel *)dataSource reloadTableView:(BOOL)reloadTableView;
+
+/**
+ *  A convenience method. Instead of worrying about making a NITableViewModel, just set the array of items.
+ */
+- (void)setDataSourceWithListArray:(NSArray *)listArray;
+- (void)setDataSourceWithListArray:(NSArray *)listArray reloadTableView:(BOOL)reloadTableView;
+
+
+- (NSIndexPath *)indexPathForTableItem:(id)object;
+
+/**
+ *  Given a table item, reload that table cell with the given animation.
+ *  @returns YES if a NSIndexPath was found and reloadCellsAtIndexPaths: was called on the table, NO otherwise.
+ */
+- (BOOL)reloadCellForTableItem:(id)object withRowAnimation:(UITableViewRowAnimation)rowAnimation;
+- (BOOL)reloadCellsForTableItems:(NSArray *)objects withRowAnimation:(UITableViewRowAnimation)rowAnimation;
+
+- (void)insertTableItem:(id)object atIndex:(int)index withRowAnimation:(UITableViewRowAnimation)animation;
+- (void)insertTableItem:(id)object atIndexPath:(NSIndexPath *)indexPath withRowAnimation:(UITableViewRowAnimation)animation;
+
+/**
+ *  Given a table item, remove that item from the datasource, and the corresponding cell from the table view with the given animation.
+ *  @returns YES if a NSIndexPath was found and deleteRowsAtIndexPaths: was called on the table, NO otherwise.
+ */
+- (BOOL)deleteTableItem:(id)object withRowAnimation:(UITableViewRowAnimation)animation;
+
+@end
+
+
+

--- a/src/models/src/NITableViewSystem.m
+++ b/src/models/src/NITableViewSystem.m
@@ -1,0 +1,306 @@
+//
+//  NITableViewSystem.m
+//  Nimbus
+//
+//  Created by Jared Egan on 2/27/13.
+//  Copyright 2013 Jeff Verkoeyen. All rights reserved.
+//
+
+#import "NITableViewSystem.h"
+#import "NICellFactory.h"
+
+#import "NITableViewModel.h"
+#import "NITableViewModel+Private.h"
+#import "NITableViewDelegate.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@interface NITableViewSystem() {
+
+}
+
+// UI
+@property (nonatomic, strong) UITableView *myTableView;
+@property (nonatomic, assign) UITableViewStyle tableViewStyle;
+
+// Data
+@property (nonatomic, strong) NICellFactory *cellFactory;
+
+@end
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@implementation NITableViewSystem
+
+#pragma mark -
+#pragma mark Init & Factory
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (id)init {
+    self = [super init];
+
+	if (self) {
+        self.cellFactory = [[NICellFactory alloc] init];
+	}
+
+	return self;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
++ (NITableViewSystem *)tableSystemWithFrame:(CGRect)frame style:(UITableViewStyle)tableStyle delegate:(id<NITableViewSystemDelegate, UIScrollViewDelegate>)delegate {
+    NITableViewSystem *result = [[NITableViewSystem alloc] init];
+    result.delegate = delegate;
+    result.tableViewStyle = tableStyle;
+    [result createTableViewWithFrame:frame];
+
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)dealloc {
+
+}
+
+#pragma mark -
+#pragma mark NITableViewSystem
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (UITableView *)tableView {
+    if (self.myTableView == nil) {
+        [self createTableView];
+    }
+
+    return self.myTableView;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)createTableView {
+    // Picks an effectively random size
+    [self createTableViewWithFrame:CGRectMake(0, 0, 320, 416)];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)createTableViewWithFrame:(CGRect)frame {
+    self.myTableView = [[UITableView alloc] initWithFrame:frame style:self.tableViewStyle];
+
+    // TODO: Ask the delete for some default styling to the tableview?
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setDataSource:(NITableViewModel *)newDataSource reloadTableView:(BOOL)reloadTableView {
+    if (self.dataSource != newDataSource) {
+        _dataSource = newDataSource;
+
+        self.tableView.dataSource = self.dataSource;
+
+        // Create delegate
+        self.tableViewDelegate = [self createTableViewDelegate];
+
+        if ([self.tableViewDelegate isKindOfClass:[NITableViewDelegate class]]) {
+            [(NITableViewDelegate *)self.tableViewDelegate setDataSource:self.dataSource];
+            [(NITableViewDelegate *)self.tableViewDelegate setTableSystem:self];
+        }
+
+        self.tableView.delegate = self.tableViewDelegate;
+    }
+
+    if (reloadTableView) {
+        [self.tableView reloadData];
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (id<UITableViewDelegate>)createTableViewDelegate {
+    // You may want to override this for custom views. You could subclass it,
+    // or we find some other way to customize it.
+    return [[NITableViewDelegate alloc]
+            initWithDataSource:nil
+            delegate:self.delegate];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setDataSourceWithListArray:(NSArray *)listArray {
+    [self setDataSourceWithListArray:listArray reloadTableView:YES];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setDataSourceWithListArray:(NSArray *)listArray reloadTableView:(BOOL)reloadTableView {
+    /*
+     // Custom logic for cell position of custom grouped cells.
+    {
+        // Set the cell positions for all KBTableItems so view controllers don't need to worry about it.
+        KBTableItem *lastKBItem = nil;
+        for (id item in listArray) {
+            BOOL reachedEndOfSection = NO;
+
+            if ([item isKindOfClass:[KBTableItem class]]) {
+                KBTableItem *kbItem = (KBTableItem *)item;
+                if (kbItem.doesPositionMatter && kbItem.cellPosition == KBTableCellBackgroundViewPositionUnspecified) {
+
+                    if (lastKBItem != nil) {
+                        kbItem.cellPosition = KBTableCellBackgroundViewPositionMiddle;
+                    } else {
+                        kbItem.cellPosition = KBTableCellBackgroundViewPositionTop;
+                    }
+
+                    lastKBItem = kbItem;
+                } else {
+                    reachedEndOfSection = YES;
+                }
+            } else {
+                reachedEndOfSection = YES;
+            }
+
+            if (reachedEndOfSection && lastKBItem != nil) {
+                if (lastKBItem.cellPosition == KBTableCellBackgroundViewPositionMiddle) {
+                    lastKBItem.cellPosition = KBTableCellBackgroundViewPositionBottom;
+                } else if (lastKBItem.cellPosition == KBTableCellBackgroundViewPositionTop) {
+                    lastKBItem.cellPosition = KBTableCellBackgroundViewPositionSingle;
+                } else {
+                    NSAssert(NO, @"Unexpected situation while trying to figure out cell positions. Must be a bug in this code.");
+                }
+                lastKBItem = nil;
+            }
+        }
+
+        if (lastKBItem.cellPosition == KBTableCellBackgroundViewPositionMiddle) {
+            lastKBItem.cellPosition = KBTableCellBackgroundViewPositionBottom;
+        } else if (lastKBItem.cellPosition == KBTableCellBackgroundViewPositionTop) {
+            lastKBItem.cellPosition = KBTableCellBackgroundViewPositionSingle;
+        } else if (lastKBItem != nil) {
+            NSAssert(NO, @"Unexpected situation while trying to figure out cell positions. Must be a bug in this code.");
+        }
+    }
+     */
+
+    [self setDataSource:[[NITableViewModel alloc] initWithListArray:listArray delegate:self]
+        reloadTableView:reloadTableView];
+}
+
+#pragma mark -
+#pragma mark NITableViewModelDelegate
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (UITableViewCell *)tableViewModel:(NITableViewModel *)tableViewModel
+                   cellForTableView:(UITableView *)tableView
+                        atIndexPath:(NSIndexPath *)indexPath
+                         withObject:(id)object {
+
+    UITableViewCell *tableViewCell = [self.cellFactory tableViewModel:tableViewModel
+                                                     cellForTableView:tableView
+                                                          atIndexPath:indexPath
+                                                           withObject:object];
+
+	if ([self.delegate respondsToSelector:@selector(tableSystem:didAssignCell:toTableItem:atIndexPath:)]) {
+		[self.delegate tableSystem:self didAssignCell:tableViewCell toTableItem:object atIndexPath:indexPath];
+	}
+
+	return tableViewCell;
+}
+
+#pragma mark -
+#pragma mark Updating
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSIndexPath *)indexPathForTableItem:(id)object {
+
+
+    int sectionIndex = 0;
+    for (NITableViewModelSection *section in self.dataSource.sections) {
+        int foundRow = [section.rows indexOfObject:object];
+
+        if (foundRow != NSNotFound) {
+            return [NSIndexPath indexPathForRow:foundRow inSection:sectionIndex];
+        }
+
+        sectionIndex++;
+    }
+
+    return nil;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)reloadCellForTableItem:(id)object withRowAnimation:(UITableViewRowAnimation)rowAnimation {
+    return [self reloadCellsForTableItems:@[object] withRowAnimation:rowAnimation];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)reloadCellsForTableItems:(NSArray *)objects withRowAnimation:(UITableViewRowAnimation)rowAnimation {
+    NSMutableArray *indexPaths = [NSMutableArray arrayWithCapacity:[objects count]];
+
+    for (id object in objects) {
+        NSIndexPath *path = [self indexPathForTableItem:object];
+        if (path) {
+            [indexPaths addObject:path];
+        }
+    }
+
+    if ([indexPaths count] == 0) {
+        return NO;
+    }
+
+    [self.tableView reloadRowsAtIndexPaths:indexPaths
+                          withRowAnimation:rowAnimation];
+
+    return YES;
+}
+
+// TODO: Finish creating methods to provide functionality that these do:
+// - (void)insertRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation
+// - (void)deleteRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)insertTableItem:(id)object atIndex:(int)index withRowAnimation:(UITableViewRowAnimation)animation {
+    [self insertTableItem:object
+              atIndexPath:[NSIndexPath indexPathForRow:index inSection:0]
+         withRowAnimation:animation];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)insertTableItem:(id)object atIndexPath:(NSIndexPath *)indexPath withRowAnimation:(UITableViewRowAnimation)animation {
+
+    // Update the datasource
+    NITableViewModelSection *section = [self.dataSource.sections objectAtIndex:indexPath.section];
+
+    NSMutableArray *newRows = [NSMutableArray arrayWithArray:section.rows];
+    [newRows insertObject:object atIndex:indexPath.row];
+    section.rows = newRows;
+
+    // Update the table
+    [self.tableView beginUpdates];
+    [self.tableView insertRowsAtIndexPaths:@[indexPath]
+                          withRowAnimation:animation];
+
+    [self.tableView endUpdates];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)deleteTableItem:(id)object withRowAnimation:(UITableViewRowAnimation)animation {
+    NSIndexPath *indexPath = [self indexPathForTableItem:object];
+
+    NSAssert(indexPath, @"Attempting to delete table item not in the table: %@", object);
+
+    if (indexPath == nil) {
+        // Can't find object, so it must be gone already. Nothing to do.
+        return NO;
+    }
+
+    // Update the datasource
+    NITableViewModelSection *section = [self.dataSource.sections objectAtIndex:indexPath.section];
+
+    NSMutableArray *newRows = [NSMutableArray arrayWithArray:section.rows];
+    [newRows removeObject:object];
+    section.rows = newRows;
+    
+    // Update the table
+    [self.tableView beginUpdates];
+    [self.tableView deleteRowsAtIndexPaths:@[indexPath]
+                          withRowAnimation:animation];
+    
+    [self.tableView endUpdates];
+    
+    return YES;
+}
+
+
+@end
+
+

--- a/src/models/src/NITableViewSystem.m
+++ b/src/models/src/NITableViewSystem.m
@@ -125,54 +125,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setDataSourceWithListArray:(NSArray *)listArray reloadTableView:(BOOL)reloadTableView {
-    /*
-     // Custom logic for cell position of custom grouped cells.
-    {
-        // Set the cell positions for all KBTableItems so view controllers don't need to worry about it.
-        KBTableItem *lastKBItem = nil;
-        for (id item in listArray) {
-            BOOL reachedEndOfSection = NO;
-
-            if ([item isKindOfClass:[KBTableItem class]]) {
-                KBTableItem *kbItem = (KBTableItem *)item;
-                if (kbItem.doesPositionMatter && kbItem.cellPosition == KBTableCellBackgroundViewPositionUnspecified) {
-
-                    if (lastKBItem != nil) {
-                        kbItem.cellPosition = KBTableCellBackgroundViewPositionMiddle;
-                    } else {
-                        kbItem.cellPosition = KBTableCellBackgroundViewPositionTop;
-                    }
-
-                    lastKBItem = kbItem;
-                } else {
-                    reachedEndOfSection = YES;
-                }
-            } else {
-                reachedEndOfSection = YES;
-            }
-
-            if (reachedEndOfSection && lastKBItem != nil) {
-                if (lastKBItem.cellPosition == KBTableCellBackgroundViewPositionMiddle) {
-                    lastKBItem.cellPosition = KBTableCellBackgroundViewPositionBottom;
-                } else if (lastKBItem.cellPosition == KBTableCellBackgroundViewPositionTop) {
-                    lastKBItem.cellPosition = KBTableCellBackgroundViewPositionSingle;
-                } else {
-                    NSAssert(NO, @"Unexpected situation while trying to figure out cell positions. Must be a bug in this code.");
-                }
-                lastKBItem = nil;
-            }
-        }
-
-        if (lastKBItem.cellPosition == KBTableCellBackgroundViewPositionMiddle) {
-            lastKBItem.cellPosition = KBTableCellBackgroundViewPositionBottom;
-        } else if (lastKBItem.cellPosition == KBTableCellBackgroundViewPositionTop) {
-            lastKBItem.cellPosition = KBTableCellBackgroundViewPositionSingle;
-        } else if (lastKBItem != nil) {
-            NSAssert(NO, @"Unexpected situation while trying to figure out cell positions. Must be a bug in this code.");
-        }
-    }
-     */
-
     [self setDataSource:[[NITableViewModel alloc] initWithListArray:listArray delegate:self]
         reloadTableView:reloadTableView];
 }

--- a/src/models/src/NITableViewSystem.m
+++ b/src/models/src/NITableViewSystem.m
@@ -24,9 +24,6 @@
 @property (nonatomic, strong) UITableView *myTableView;
 @property (nonatomic, assign) UITableViewStyle tableViewStyle;
 
-// Data
-@property (nonatomic, strong) NICellFactory *cellFactory;
-
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -48,11 +45,11 @@
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-+ (NITableViewSystem *)tableSystemWithFrame:(CGRect)frame style:(UITableViewStyle)tableStyle delegate:(id<NITableViewSystemDelegate, UIScrollViewDelegate>)delegate {
-    NITableViewSystem *result = [[NITableViewSystem alloc] init];
++ (id)tableSystemWithFrame:(CGRect)frame style:(UITableViewStyle)tableStyle delegate:(id<NITableViewSystemDelegate, UIScrollViewDelegate>)delegate {
+    NITableViewSystem *result = [[self alloc] init];
     result.delegate = delegate;
     result.tableViewStyle = tableStyle;
-    [result createTableViewWithFrame:frame];
+    result.myTableView = [result createTableViewWithFrame:frame withStyle:result.tableViewStyle];
 
     return result;
 }
@@ -67,23 +64,28 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 - (UITableView *)tableView {
     if (self.myTableView == nil) {
-        [self createTableView];
+        self.myTableView = [self createTableView];
     }
 
     return self.myTableView;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)createTableView {
+- (UITableView *)createTableView {
     // Picks an effectively random size
-    [self createTableViewWithFrame:CGRectMake(0, 0, 320, 416)];
+    return [self createTableViewWithFrame:CGRectMake(0, 0, 320, 416) withStyle:UITableViewStylePlain];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)createTableViewWithFrame:(CGRect)frame {
-    self.myTableView = [[UITableView alloc] initWithFrame:frame style:self.tableViewStyle];
+- (UITableView *)createTableViewWithFrame:(CGRect)frame withStyle:(UITableViewStyle)tableStyle {
+    UITableView *result = [[UITableView alloc] initWithFrame:frame style:tableStyle];
 
-    // TODO: Ask the delete for some default styling to the tableview?
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setDataSource:(NITableViewModel *)newDataSource {
+    [self setDataSource:newDataSource reloadTableView:YES];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/models/src/NimbusModels.h
+++ b/src/models/src/NimbusModels.h
@@ -484,5 +484,7 @@ typedef enum {
 #import "NIRadioGroup.h"
 #import "NIRadioGroupController.h"
 #import "NITableViewActions.h"
+#import "NITableViewSystem.h"
+#import "NITableViewDelegate.h"
 
 /**@}*/


### PR DESCRIPTION
NITableViewSystem provides a simplified way for creating/managing the combination of UITableViews, NICellFactory & NITableViewModel that is needed to use Nimbus' Table Models. It makes it easier to use the table models, easier to have multiple table views per view controller, and reduces the amount of properties you need to keep track of to make things work, especially for the most common use cases.

NITableViewDelegate conforms to UITableViewDelegate and handles the height for cells that conform to NICell. It itself contains a reference to id<NITableViewSystemDelegate, UIScrollViewDelegate>. It will tell this delegate when table objects are selected, when a cell is set up with an object and it will also forward UIScrollViewDelegate messages to this delegate, which is a common use case for fun interfaces.

NITableViewDelegate can be subclassed to provide custom header / footer views.

This is used frequently in a soon-to-be shipping app with our own table cell catalog.

This pull request isn't totally ready, there's a lack of documentation and the methods for updating, removing & inserting table objects & cells should use NIMutableTableViewModel. But I wanted to get some feedback on the addition before I go whole hog and clean this up.