### PR TITLE
Fix issue 351: Vertical text alignment

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1370,6 +1370,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
 
   for (CFIndex lineIndex = 0; lineIndex < numberOfLines; lineIndex++) {
     CGPoint lineOrigin = lineOrigins[lineIndex];
+    lineOrigin.y -= rect.origin.y; // adjust for verticalTextAlignment
     CGContextSetTextPosition(ctx, lineOrigin.x, lineOrigin.y);
     CTLineRef line = CFArrayGetValueAtIndex(lines, lineIndex);
 


### PR DESCRIPTION
`NIAttributedLabel.verticalTextAlignment` stopped working correctly in commit c856b9b.  In that commit, the code for rendering attributed labels changed dramatically.

The old code called CoreText's `CTFrameDraw()` to render the entire text.  The new code repeatedly calls `CTLineDraw()` after asking for the origin position of each line of text.

But when you call `CTFrameGetLineOrigins()` to get the origins of the lines, it would appear that that function is not accounting for the `path` that was set on the frame in the earlier call to `CTFramesetterCreateFrame()`.

My fix is to manually adjust the `origin.y` of each line before drawing.  Numerous other places in the same file that call `CTFrameGetLineOrigins()`, e.g. hit detection and link rendering, already contain similar adjustments (in `[linkAtPoint:]`, `[isPoint:nearLink:]`, `[_rectsForLink:]`, `[drawImages]`, and `[drawHighlightWithRect:]`).
