### PR TITLE
Add some object-state methods on NITableViewActions

### DIFF
--- a/src/models/src/NITableViewActions.h
+++ b/src/models/src/NITableViewActions.h
@@ -53,6 +53,11 @@ tableView.delegate = [self.actions forwardingTo:self];
 - (id<UITableViewDelegate>)forwardingTo:(id<UITableViewDelegate>)forwardDelegate;
 - (void)removeForwarding:(id<UITableViewDelegate>)forwardDelegate;
 
+#pragma mark Object state
+
+- (UITableViewCellAccessoryType)accessoryTypeForObject:(id)object;
+- (UITableViewCellSelectionStyle)selectionStyleForObject:(id)object;
+
 #pragma mark Configurable Properties
 
 @property (nonatomic, assign) UITableViewCellSelectionStyle tableViewCellSelectionStyle;
@@ -88,6 +93,26 @@ self.tableView.delegate = [self.actions forwardingTo:self.tableView.delegate];
  *
  *      @param forwardDelegate The delegate to stop forwarding invocations to.
  *      @fn NITableViewActions::removeForwarding:
+ */
+
+/** @name Object State */
+
+/**
+ * Returns the accessory type this actions object will apply to a cell for the
+ * given object when it is displayed.
+ *
+ *      @param object The object to determine the accessory type for.
+ *      @returns the accessory type this object's cell will have.
+ *      @fn NITableViewActions::accessoryTypeForObject:
+ */
+
+/**
+ * Returns the cell selection style this actions object will apply to a cell
+ * for the given object when it is displayed.
+ *
+ *      @param object The object to determine the selection style for.
+ *      @returns the selection style this object's cell will have.
+ *      @fn NITableViewActions::selectionStyleForObject:
  */
 
 /** @name Configurable Properties */

--- a/src/models/src/NITableViewActions.m
+++ b/src/models/src/NITableViewActions.m
@@ -127,6 +127,41 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Object State
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (UITableViewCellAccessoryType)accessoryTypeForObject:(id)object {
+  NIObjectActions* action = [self actionForObjectOrClassOfObject:object];
+  // Detail disclosure indicator takes precedence over regular disclosure indicator.
+  if (nil != action.detailAction || nil != action.detailSelector) {
+    return UITableViewCellAccessoryDetailDisclosureButton;
+
+  } else if (nil != action.navigateAction || nil != action.navigateSelector) {
+    return  UITableViewCellAccessoryDisclosureIndicator;
+
+  }
+  // We must maintain consistency of modifications to the accessoryType within this call due
+  // to the fact that cells will be reused.
+  return UITableViewCellAccessoryNone;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (UITableViewCellSelectionStyle)selectionStyleForObject:(id)object {
+  // If the cell is tappable, reflect that in the selection style.
+  NIObjectActions* action = [self actionForObjectOrClassOfObject:object];
+  if (action.navigateAction || action.tapAction
+      || action.navigateSelector || action.tapSelector) {
+    return self.tableViewCellSelectionStyle;
+
+  }
+  return UITableViewCellSelectionStyleNone;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - UITableViewDelegate
 
 
@@ -136,34 +171,9 @@
   if ([tableView.dataSource isKindOfClass:[NITableViewModel class]]) {
     NITableViewModel* model = (NITableViewModel *)tableView.dataSource;
     id object = [model objectAtIndexPath:indexPath];
-
     if ([self isObjectActionable:object]) {
-      NIObjectActions* action = [self actionForObjectOrClassOfObject:object];
-
-      // Detail disclosure indicator takes precedence over regular disclosure indicator.
-      if (nil != action.detailAction || nil != action.detailSelector) {
-        cell.accessoryType = UITableViewCellAccessoryDetailDisclosureButton;
-
-      } else if (nil != action.navigateAction || nil != action.navigateSelector) {
-        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-
-      } else {
-        // We must maintain consistency of modifications to the accessoryType within this call due
-        // to the fact that cells will be reused.
-        cell.accessoryType = UITableViewCellAccessoryNone;
-      }
-
-      // If the cell is tappable, reflect that in the selection style.
-      if (action.navigateAction || action.tapAction
-          || action.navigateSelector || action.tapSelector) {
-        cell.selectionStyle = self.tableViewCellSelectionStyle;
-
-      } else {
-        // We must maintain consistency of modifications to the selectionStyle within this call due
-        // to the fact that cells will be reused.
-        cell.selectionStyle = UITableViewCellSelectionStyleNone;
-      }
-
+      cell.accessoryType = [self accessoryTypeForObject:object];
+      cell.selectionStyle = [self selectionStyleForObject:object];
     } else {
       cell.accessoryType = UITableViewCellAccessoryNone;
       cell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -177,7 +187,6 @@
     }
   }
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
Adds a couple of methods to NITableViewActions to allow callers to know which accessory type or selection style the NITableViewActions instance would set for the cell for a given object. 
This is required because callers may need to know if accessories are present when calculating layout such as the height of cells, but the only way for layout code to find out if they have accessories at the moment is to call tableView:willDisplayCell:forRowAtIndexPath:, which has the side effect of lying to the viewcontroller about which cells are being displayed.
