### PR TITLE
Bug fix: images don't load when network path contains spaces

### DIFF
--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -322,7 +322,7 @@
     // Check for file URLs.
     if ([pathToNetworkImage hasPrefix:@"/"]) {
       // If the url starts with / then it's likely a file URL, so treat it accordingly.
-      url = [NSURL fileURLWithPath:[pathToNetworkImage stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+      url = [NSURL fileURLWithPath:pathToNetworkImage];
 
     } else {
       // Otherwise we assume it's a regular URL.


### PR DESCRIPTION
Due to `[NSURL URLWithString:]` returning nil to strings containing spaces, network images with paths containing spaces would fail to load.

`[NSString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]` is used to replace spaces with %20, which works.
