### PR TITLE
Don't draw cell backgrounds on half pixels on non-retina devices

### DIFF
--- a/src/models/src/NICellBackgrounds.m
+++ b/src/models/src/NICellBackgrounds.m
@@ -66,7 +66,7 @@ static const CGSize kCellImageSize = {44, 44};
 }
 
 // We want to draw the borders and shadows on single retina-pixel boundaries if possible, but
-// but we need to avoid doing this on non-retina devices because it'll look blurry.
+// we need to avoid doing this on non-retina devices because it'll look blurry.
 + (CGFloat)minPixelOffset {
   if (NIIsRetina()) {
     return 0.5f;


### PR DESCRIPTION
On non-retina devices the shadows/border overlapping thing for cell backgrounds is pretty blurry and sticks out near our card-styled (but not drawn using cell backgrounds) views, and also makes it difficult to line our views up and have them look correct - the half-white/half-shadow edge makes the card look bigger than it is. On retina we don't have any such problem though, so half-pixels are ok there.

Provides a minPixelOffset so that people can bail out to the old behaviour if they so choose.
