### PR TITLE
Update compile time checks to avoid usage of UITextAlignment under iOS 7 SDK and remove duplicated NSLineBreakMode conversion code.

### DIFF
--- a/examples/catalog/NimbusCatalog.xcodeproj/project.pbxproj
+++ b/examples/catalog/NimbusCatalog.xcodeproj/project.pbxproj
@@ -1078,6 +1078,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Catalog/NimbusCatalog-Prefix.pch";
 				INFOPLIST_FILE = "Catalog/NimbusCatalog-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Nimbus;
 				WRAPPER_EXTENSION = app;
@@ -1090,6 +1091,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Catalog/NimbusCatalog-Prefix.pch";
 				INFOPLIST_FILE = "Catalog/NimbusCatalog-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Nimbus;
 				WRAPPER_EXTENSION = app;

--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -126,13 +126,14 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
 
 
 @interface NIAttributedLabel(ConversionUtilities)
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < NIIOS_6_0
+// Only use UITextAlignment if deployment target is less than 6.0 and
+// not on iOS 7 SDK.
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < NIIOS_7_0 && __IPHONE_OS_VERSION_MIN_REQUIRED < NIIOS_6_0
 + (CTTextAlignment)alignmentFromUITextAlignment:(UITextAlignment)alignment;
-+ (CTLineBreakMode)lineBreakModeFromUILineBreakMode:(NSLineBreakMode)lineBreakMode;
 #else
 + (CTTextAlignment)alignmentFromUITextAlignment:(NSTextAlignment)alignment;
-+ (CTLineBreakMode)lineBreakModeFromUILineBreakMode:(NSLineBreakMode)lineBreakMode;
 #endif
++ (CTLineBreakMode)lineBreakModeFromUILineBreakMode:(NSLineBreakMode)lineBreakMode;
 + (NSMutableAttributedString *)mutableAttributedStringFromLabel:(UILabel *)label;
 @end
 
@@ -364,7 +365,10 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < NIIOS_6_0
+
+// Only use UITextAlignment if deployment target is less than 6.0 and
+// not on iOS 7 SDK.
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < NIIOS_7_0 && __IPHONE_OS_VERSION_MIN_REQUIRED < NIIOS_6_0
 - (void)setTextAlignment:(UITextAlignment)textAlignment {
   // UILabel doesn't implement UITextAlignmentJustify, so we can't call super when this is the case
   // or the app will crash.
@@ -401,7 +405,6 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < NIIOS_6_0
 - (void)setLineBreakMode:(NSLineBreakMode)lineBreakMode {
   [super setLineBreakMode:lineBreakMode];
 
@@ -411,17 +414,6 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
     [self.mutableAttributedString setTextAlignment:alignment lineBreakMode:lineBreak lineHeight:self.lineHeight];
   }
 }
-#else
-- (void)setLineBreakMode:(NSLineBreakMode)lineBreakMode {
-  [super setLineBreakMode:lineBreakMode];
-
-  if (nil != self.mutableAttributedString) {
-    CTTextAlignment alignment = [self.class alignmentFromUITextAlignment:self.textAlignment];
-    CTLineBreakMode lineBreak = [self.class lineBreakModeFromUILineBreakMode:lineBreakMode];
-    [self.mutableAttributedString setTextAlignment:alignment lineBreakMode:lineBreak lineHeight:self.lineHeight];
-  }
-}
-#endif
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1709,7 +1701,7 @@ CGFloat ImageDelegateGetWidthCallback(void* refCon) {
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < NIIOS_6_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < NIIOS_7_0 && __IPHONE_OS_VERSION_MIN_REQUIRED < NIIOS_6_0
 + (CTTextAlignment)alignmentFromUITextAlignment:(UITextAlignment)alignment {
   // UITextAlignmentJustify is not part of the UITextAlignment enumeration, so we cast to NSInteger
   // to tell Xcode not to coerce us into only using real UITextAlignment valus.
@@ -1735,7 +1727,6 @@ CGFloat ImageDelegateGetWidthCallback(void* refCon) {
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < NIIOS_6_0
 + (CTLineBreakMode)lineBreakModeFromUILineBreakMode:(NSLineBreakMode)lineBreakMode {
   switch (lineBreakMode) {
     case NSLineBreakByWordWrapping: return kCTLineBreakByWordWrapping;
@@ -1747,20 +1738,6 @@ CGFloat ImageDelegateGetWidthCallback(void* refCon) {
     default: return 0;
   }
 }
-#else
-+ (CTLineBreakMode)lineBreakModeFromUILineBreakMode:(NSLineBreakMode)lineBreakMode {
-  switch (lineBreakMode) {
-    case NSLineBreakByWordWrapping: return kCTLineBreakByWordWrapping;
-    case NSLineBreakByCharWrapping: return kCTLineBreakByCharWrapping;
-    case NSLineBreakByClipping: return kCTLineBreakByClipping;
-    case NSLineBreakByTruncatingHead: return kCTLineBreakByTruncatingHead;
-    case NSLineBreakByTruncatingTail: return kCTLineBreakByWordWrapping; // We handle truncation ourself.
-    case NSLineBreakByTruncatingMiddle: return kCTLineBreakByTruncatingMiddle;
-    default: return 0;
-  }
-}
-#endif
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 + (NSMutableAttributedString *)mutableAttributedStringFromLabel:(UILabel *)label {

--- a/src/core/src/NISDKAvailability.h
+++ b/src/core/src/NISDKAvailability.h
@@ -110,6 +110,11 @@
  */
 #define NIIOS_6_1     60100
 
+/**
+ * Release unknown
+ */
+#define NIIOS_7_0     70000
+
 #ifndef kCFCoreFoundationVersionNumber_iPhoneOS_2_0
 #define kCFCoreFoundationVersionNumber_iPhoneOS_2_0 478.23
 #endif


### PR DESCRIPTION
Defines NIIOS_7_0 and selects usage of NSTextAlignment even when the IPHONE_DEPLOYMENT_TARGET is set to 5.1 or below.

Also removes identical blocks for converting NSLineBreakMode.
