### PR TITLE
Revert adding support for accessoryView declaration to NIActions and NITableViewActions.

### DIFF
--- a/src/core/src/NIActions+Subclassing.h
+++ b/src/core/src/NIActions+Subclassing.h
@@ -34,6 +34,5 @@
 @property (nonatomic, NI_WEAK) id target;
 
 - (NIObjectActions *)actionForObjectOrClassOfObject:(id<NSObject>)object;
-- (UIView *)accessoryViewForObject:(id<NSObject>)object;
 
 @end

--- a/src/core/src/NIActions.h
+++ b/src/core/src/NIActions.h
@@ -15,7 +15,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 /**
  * For attaching actions to objects.
@@ -73,28 +72,6 @@ NSArray *objects = @[
  }];
 @endcode
  *
- * <h3>Setting a Custom Accessory View</h3>
- * For either tap block or selector invocations, there is an option to set a custom accessoryView.
- *
- * The following is an example of setting an accessoryView:
- *
- @code
- UISwitch *switchControl = [[UISwitch alloc] init];
- switchControl.tag = 1;
- [switchControl addTarget:self action:@selector(switched:) forControlEvents:UIControlEventValueChanged];
-
- NSArray *objects = @[
-    [NITitleCellObject objectWithTitle:@"Custom Accessory View"],
-    [self.actions attachToObject:[NITitleCellObject objectWithTitle:@"UISwitch Cell"]
-                   accessoryView:switchControl
-                     tapSelector:nil]
- ];
-
- - (void)switched:(id)switchControl {
-    NSLog(@"Switch %i is now %@.", switchControl.tag, (switchControl.on) ? @"on" : @"off");
- }
- @endcode
- *
  */
 @interface NIActions : NSObject
 
@@ -106,12 +83,10 @@ NSArray *objects = @[
 - (id)attachToObject:(id<NSObject>)object tapBlock:(NIActionBlock)action;
 - (id)attachToObject:(id<NSObject>)object detailBlock:(NIActionBlock)action;
 - (id)attachToObject:(id<NSObject>)object navigationBlock:(NIActionBlock)action;
-- (id)attachToObject:(id<NSObject>)object accessoryView:(UIView *)accessoryView tapBlock:(NIActionBlock)action;
 
 - (id)attachToObject:(id<NSObject>)object tapSelector:(SEL)selector;
 - (id)attachToObject:(id<NSObject>)object detailSelector:(SEL)selector;
 - (id)attachToObject:(id<NSObject>)object navigationSelector:(SEL)selector;
-- (id)attachToObject:(id<NSObject>)object accessoryView:(UIView *)accessoryView tapSelector:(SEL)selector;
 
 #pragma mark Mapping Classes
 
@@ -126,7 +101,6 @@ NSArray *objects = @[
 #pragma mark Object State
 
 - (BOOL)isObjectActionable:(id<NSObject>)object;
-- (BOOL)objectHasAccessoryView:(id<NSObject>)object;
 
 + (id)objectFromKeyClass:(Class)keyClass map:(NSMutableDictionary *)map;
 
@@ -240,31 +214,6 @@ NIActionBlock NIPushControllerAction(Class controllerClass);
  */
 
 /**
- * Attaches a tap action with an accessory view to the given object.
- *
- * A cell with an attached tap action will have its selectionStyle set to
- * @c tableViewCellSelectionStyle when the cell is displayed.
- *
- * The action will be executed when the object's corresponding cell is tapped. The object argument
- * of the block will be the object to which this action was attached. The target argument of the
- * block will be this receiver's @c target.
- *
- * Return NO if the tap action is used to present a modal view controller. This provides a visual
- * reminder to the user when the modal controller is dismissed as to which cell was tapped to invoke
- * the modal controller.
- *
- * The tap action will be invoked first, followed by the navigation action if one is attached.
- *
- *      @param object The object to attach the action to. This object must be contained within
- *                    an NITableViewModel.
- *      @param accessoryView The custom accessoryView to be added. If set, ignore cell accessoryType.
- *      @param action The tap action block.
- *      @returns The object that you attached this action to.
- *      @fn NIActions::attachToObject:accessoryView:tapBlock:
- *      @sa NIActions::attachToObject:accessoryView:tapSelector:
-*/
-
-/**
  * Attaches a tap selector to the given object.
  *
  * The method signature for the selector is:
@@ -343,38 +292,6 @@ NIActionBlock NIPushControllerAction(Class controllerClass);
  *      @returns The object that you attached this action to.
  *      @fn NIActions::attachToObject:navigationSelector:
  *      @sa NIActions::attachToObject:navigationBlock:
- */
-
-/**
- * Attaches a tap selector with an accessory view to the given object.
- *
- * The method signature for the selector is:
- @code
- - (BOOL)didTapObject:(id)object;
- @endcode
- *
- * A cell with an attached tap action will have its selectionStyle set to
- * @c tableViewCellSelectionStyle when the cell is displayed.
- *
- * The selector will be performed on the action object's target when a cell with a tap selector is
- * tapped, unless that selector does not exist on the @c target in which case nothing happens.
- *
- * If the selector invocation returns YES then the cell will be deselected immediately after the
- * invocation completes its execution. If NO is returned then the cell's selection will remain.
- *
- * Return NO if the tap action is used to present a modal view controller. This provides a visual
- * reminder to the user when the modal controller is dismissed as to which cell was tapped to invoke
- * the modal controller.
- *
- * The tap action will be invoked first, followed by the navigation action if one is attached.
- *
- *      @param object The object to attach the selector to. This object must be contained within
- *                    an NITableViewModel.
- *      @param accessoryView The custom accessoryView to be added. If set, ignore cell accessoryType.
- *      @param selector The selector that will be invoked by this action.
- *      @returns The object that you attached this action to.
- *      @fn NIActions::attachToObject:accessoryView:tapSelector:
- *      @sa NIActions::attachToObject:accessoryView:tapBlock:
  */
 
 /** @name Mapping Classes */

--- a/src/core/src/NIActions.m
+++ b/src/core/src/NIActions.m
@@ -25,9 +25,7 @@
 
 @property (nonatomic, NI_STRONG) NSMutableDictionary* objectMap;
 @property (nonatomic, NI_STRONG) NSMutableSet* objectSet;
-@property (nonatomic, NI_STRONG) NSMutableDictionary* objectClassMap;
-@property (nonatomic, NI_STRONG) NSMutableDictionary* accessoryMap;
-@property (nonatomic, NI_STRONG) NSMutableSet* accessorySet;
+@property (nonatomic, NI_STRONG) NSMutableDictionary* classMap;
 
 @end
 
@@ -39,9 +37,7 @@
 
 @synthesize objectMap = _objectMap;
 @synthesize objectSet = _objectSet;
-@synthesize objectClassMap = _objectClassMap;
-@synthesize accessoryMap = _accessoryMap;
-@synthesize accessorySet = _accessorySet;
+@synthesize classMap = _classMap;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -50,9 +46,7 @@
     _target = target;
     _objectMap = [[NSMutableDictionary alloc] init];
     _objectSet = [[NSMutableSet alloc] init];
-    _objectClassMap = [[NSMutableDictionary alloc] init];
-    _accessoryMap = [[NSMutableDictionary alloc] init];
-    _accessorySet = [[NSMutableSet alloc] init];
+    _classMap = [[NSMutableDictionary alloc] init];
   }
   return self;
 }
@@ -82,9 +76,6 @@
 // actionForObjectOrClassOfObject: determines whether an action has been attached to an object
 // or class of object and then returns the NIObjectActions or nil if no actions have been attached.
 //
-// accessoryViewForObject: determines whether an accessoryView has been attached to an object
-// and then returns the UIView or nil if no accessoryView has been attached.
-//
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -105,10 +96,10 @@
 // Retrieves an NIObjectActions object for the given class or creates one if it doesn't yet exist
 // so that actions may be attached.
 - (NIObjectActions *)actionForClass:(Class)class {
-  NIObjectActions* action = [self.objectClassMap objectForKey:class];
+  NIObjectActions* action = [self.classMap objectForKey:class];
   if (nil == action) {
     action = [[NIObjectActions alloc] init];
-    [self.objectClassMap setObject:action forKey:(id<NSCopying>)class];
+    [self.classMap setObject:action forKey:(id<NSCopying>)class];
   }
   return action;
 }
@@ -120,17 +111,9 @@
   id key = [self keyForObject:object];
   NIObjectActions* action = [self.objectMap objectForKey:key];
   if (nil == action) {
-    action = [self.class objectFromKeyClass:object.class map:self.objectClassMap];
+    action = [self.class objectFromKeyClass:object.class map:self.classMap];
   }
   return action;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Fetches any accessoryView for a given object.
-- (UIView *)accessoryViewForObject:(id<NSObject>)object {
-  id key = [self keyForObject:object];
-  return [self.accessoryMap objectForKey:key];
 }
 
 
@@ -164,17 +147,6 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (id)attachToObject:(id<NSObject>)object accessoryView:(UIView *)accessoryView tapBlock:(NIActionBlock)action {
-  [self attachToObject:object tapBlock:action];
-  if (accessoryView) {
-    [self.accessorySet addObject:object];
-    [self.accessoryMap setObject:accessoryView forKey:[self keyForObject:object]];
-  }
-  return object;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)attachToObject:(id<NSObject>)object tapSelector:(SEL)selector {
   [self.objectSet addObject:object];
   [self actionForObject:object].tapSelector = selector;
@@ -194,17 +166,6 @@
 - (id)attachToObject:(id<NSObject>)object navigationSelector:(SEL)selector {
   [self.objectSet addObject:object];
   [self actionForObject:object].navigateSelector = selector;
-  return object;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-- (id)attachToObject:(id<NSObject>)object accessoryView:(UIView *)accessoryView tapSelector:(SEL)selector {
-  [self attachToObject:object tapSelector:selector];
-  if (accessoryView) {
-    [self.accessorySet addObject:object];
-    [self.accessoryMap setObject:accessoryView forKey:[self keyForObject:object]];
-  }
   return object;
 }
 
@@ -253,19 +214,9 @@
 
   BOOL objectIsActionable = [self.objectSet containsObject:object];
   if (!objectIsActionable) {
-    objectIsActionable = (nil != [self.class objectFromKeyClass:object.class map:self.objectClassMap]);
+    objectIsActionable = (nil != [self.class objectFromKeyClass:object.class map:self.classMap]);
   }
   return objectIsActionable;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-- (BOOL)objectHasAccessoryView:(id<NSObject>)object {
-  if (nil == object) {
-    return NO;
-  }
-
-  return [self.accessorySet containsObject:object];
 }
 
 

--- a/src/models/src/NITableViewActions.m
+++ b/src/models/src/NITableViewActions.m
@@ -172,18 +172,9 @@
     NITableViewModel* model = (NITableViewModel *)tableView.dataSource;
     id object = [model objectAtIndexPath:indexPath];
     if ([self isObjectActionable:object]) {
-      if ([self objectHasAccessoryView:object]) {
-        cell.accessoryView = [self accessoryViewForObject:object];
-      } else {
-        // TODO: Need to ensure accessoryView is cleared if this cell
-        //       is being re-used, but cell.accessoryView = nil will
-        //       override legitimate uses of the accessoryView. Maybe this
-        //       accessoryType should be set elsewhere.
-        cell.accessoryType = [self accessoryTypeForObject:object];
-      }
+      cell.accessoryType = [self accessoryTypeForObject:object];
       cell.selectionStyle = [self selectionStyleForObject:object];
     } else {
-      // TODO: same here as above in for setting accessoryView to nil.
       cell.accessoryType = UITableViewCellAccessoryNone;
       cell.selectionStyle = UITableViewCellSelectionStyleNone;
     }


### PR DESCRIPTION
Turns out this change isn't quite right and breaks some of the model/view separations. Reverting this to rethink the strategy again because we can accomplish the same by subclassing the Cells and CellObjects instead.
