### PR TITLE
Add `intrinsicContentSize` to the `NIBadgeView` to make it auto layout compatible

### DIFF
--- a/src/badge/src/NIBadgeView.m
+++ b/src/badge/src/NIBadgeView.m
@@ -81,16 +81,27 @@ static const CGFloat kBadgeLineSize = 2.0f;
                     stringSize.height + kVerticalMargins);
 }
 
+- (CGSize)intrinsicContentSize
+{
+    return [self sizeThatFits:self.bounds.size];
+}
+
 - (void)setText:(NSString *)text {
   _text = text;
 
   [self setNeedsDisplay];
+    
+  if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)])
+    [self invalidateIntrinsicContentSize];
 }
 
 - (void)setFont:(UIFont *)font {
   _font = font;
 
   [self setNeedsDisplay];
+    
+  if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)])
+    [self invalidateIntrinsicContentSize];
 }
 
 - (void)setTintColor:(UIColor *)tintColor {


### PR DESCRIPTION
So, here is an improvement of the NIBadgeView to make it autolayout compatible. I simply added `intrinsicContentSize` definition
