### PR TITLE
Fix the analyzer error in NIAttributedLabel under XCode5.

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -110,7 +110,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
 
 @interface NIAttributedLabel() <UIActionSheetDelegate>
 @property (nonatomic, NI_STRONG) NSMutableAttributedString* mutableAttributedString;
-@property (nonatomic, assign) CTFrameRef textFrame;
+@property (nonatomic, assign) CTFrameRef textFrame; // CFType, manually managed lifetime, see setter.
 @property (assign) BOOL detectingLinks; // Atomic.
 @property (nonatomic, assign) BOOL linksHaveBeenDetected;
 @property (nonatomic, copy) NSArray* detectedlinkLocations;
@@ -179,8 +179,26 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
 - (void)dealloc {
   [_longPressTimer invalidate];
 
-  if (nil != _textFrame) {
+  // The property is marked 'assign', but retain count for this CFType is managed here and via
+  // the setter.
+  if (NULL != _textFrame) {
     CFRelease(_textFrame);
+  }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setTextFrame:(CTFrameRef)textFrame {
+  // The property is marked 'assign', but retain count for this CFType is managed via this setter
+  // and -dealloc.
+  if (textFrame != _textFrame) {
+    if (NULL != _textFrame) {
+      CFRelease(_textFrame);
+    }
+    if (NULL != textFrame) {
+      CFRetain(textFrame);
+    }
+    _textFrame = textFrame;
   }
 }
 
@@ -220,10 +238,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)resetTextFrame {
-  if (nil != self.textFrame) {
-    CFRelease(self.textFrame);
-    self.textFrame = nil;
-  }
+  self.textFrame = NULL;
   self.accessibleElements = nil;
 }
 
@@ -1469,13 +1484,15 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
     CGAffineTransform transform = [self _transformForCoreText];
     CGContextConcatCTM(ctx, transform);
 
-    if (nil == self.textFrame) {
+    if (NULL == self.textFrame) {
       CFAttributedStringRef attributedString = (__bridge CFAttributedStringRef)attributedStringWithLinks;
       CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(attributedString);
 
       CGMutablePathRef path = CGPathCreateMutable();
-      CGPathAddRect(path, nil, rect);
-      self.textFrame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), path, NULL);
+      CGPathAddRect(path, NULL, rect);
+      CTFrameRef textFrame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), path, NULL);
+      self.textFrame = textFrame;
+      CFRelease(textFrame);
       CGPathRelease(path);
       CFRelease(framesetter);
     }


### PR DESCRIPTION
Rather then having the setter assume an existing retain (which confuses the Xcode 5 analyzer); add a setter to manage the lifetime of the textFrame. The code calling the setter can then be normally balanced.
