### PR TITLE
[NIOverviewGraphView] Guard against zero x/y ranges to prevent runtime assertions on iOS 7.

### DIFF
--- a/src/overview/src/NIOverviewGraphView.m
+++ b/src/overview/src/NIOverviewGraphView.m
@@ -47,6 +47,9 @@
 
   CGFloat xRange = [self.dataSource graphViewXRange:self];
   CGFloat yRange = [self.dataSource graphViewYRange:self];
+  if (xRange == 0 || yRange == 0) {
+    return;
+  }
 
   [self.dataSource resetPointIterator];
 


### PR DESCRIPTION
Guard against zero x/y ranges to prevent runtime assertions on iOS 7.
