### PR TITLE
Fixed debugging functions for Objective C++

### DIFF
--- a/src/core/src/NIDebuggingTools.h
+++ b/src/core/src/NIDebuggingTools.h
@@ -94,6 +94,10 @@
  */
 #import <TargetConditionals.h>
 
+#if defined __cplusplus
+extern "C" {
+#endif
+
 int NIIsInDebugger(void);
 #if TARGET_IPHONE_SIMULATOR
 // We leave the __asm__ in this macro so that when a break occurs, we don't have to step out of
@@ -182,6 +186,9 @@ xx, ##__VA_ARGS__)
  */
 #define NIDINFO(xx, ...)  NIDCONDITIONLOG((NILOGLEVEL_INFO <= NIMaxLogLevel), xx, ##__VA_ARGS__)
 
+#if defined __cplusplus
+};
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /**@}*/// End of Debugging Tools //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes using the NIIsInDebugger function in Objective C++.
