### PR TITLE
Adds ni_ prefix to NSString category methods.

### DIFF
--- a/src/core/src/NSString+NimbusCore.h
+++ b/src/core/src/NSString+NimbusCore.h
@@ -26,21 +26,34 @@
 
 - (CGFloat)heightWithFont: (UIFont*)font
        constrainedToWidth: (CGFloat)width
-            lineBreakMode: (NSLineBreakMode)lineBreakMode;
+            lineBreakMode: (NSLineBreakMode)lineBreakMode __attribute__((deprecated));
+
+- (CGFloat)ni_heightWithFont: (UIFont*)font
+          constrainedToWidth: (CGFloat)width
+               lineBreakMode: (NSLineBreakMode)lineBreakMode;
 
 #pragma mark URL queries
 
-- (NSDictionary*)queryContentsUsingEncoding:(NSStringEncoding)encoding;
-- (NSString *)stringByAddingPercentEscapesForURLParameter;
-- (NSString*)stringByAddingQueryDictionary:(NSDictionary*)query;
+- (NSDictionary*)queryContentsUsingEncoding:(NSStringEncoding)encoding __attribute__((deprecated));
+- (NSString *)stringByAddingPercentEscapesForURLParameter __attribute__((deprecated));
+- (NSString*)stringByAddingQueryDictionary:(NSDictionary*)query __attribute__((deprecated));
+
+- (NSDictionary*)ni_queryContentsUsingEncoding:(NSStringEncoding)encoding;
+- (NSString *)ni_stringByAddingPercentEscapesForURLParameter;
+- (NSString*)ni_stringByAddingQueryDictionary:(NSDictionary*)query;
 
 #pragma mark Versions
 
-- (NSComparisonResult)versionStringCompare:(NSString *)other;
+- (NSComparisonResult)versionStringCompare:(NSString *)other __attribute__((deprecated));;
+
+- (NSComparisonResult)ni_versionStringCompare:(NSString *)other;
 
 #pragma mark Hashing
 
-@property (nonatomic, readonly) NSString* md5Hash;
-@property (nonatomic, readonly) NSString* sha1Hash;
+@property (nonatomic, readonly) NSString* md5Hash __attribute__((deprecated));
+@property (nonatomic, readonly) NSString* sha1Hash __attribute__((deprecated));
+
+@property (nonatomic, readonly) NSString* ni_md5Hash;
+@property (nonatomic, readonly) NSString* ni_sha1Hash;
 
 @end

--- a/src/core/src/NSString+NimbusCore.m
+++ b/src/core/src/NSString+NimbusCore.m
@@ -39,14 +39,25 @@ NI_FIX_CATEGORY_BUG(NSStringNimbusCore)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /**
+ * Deprecated. Use ni_queryContentsUsingEncoding instead.
+ */
+- (CGFloat)heightWithFont:(UIFont*)font
+       constrainedToWidth:(CGFloat)width
+            lineBreakMode:(NSLineBreakMode)lineBreakMode {
+  return [self ni_heightWithFont:font
+              constrainedToWidth:width
+                   lineBreakMode:lineBreakMode];
+}
+
+/**
  * Calculates the height of this text given the font, max width, and line break mode.
  *
  * A convenience wrapper for sizeWithFont:constrainedToSize:lineBreakMode:
  */
 // COV_NF_START
-- (CGFloat)heightWithFont:(UIFont*)font
-       constrainedToWidth:(CGFloat)width
-            lineBreakMode:(NSLineBreakMode)lineBreakMode {
+- (CGFloat)ni_heightWithFont:(UIFont*)font
+          constrainedToWidth:(CGFloat)width
+               lineBreakMode:(NSLineBreakMode)lineBreakMode {
   return [self sizeWithFont:font
           constrainedToSize:CGSizeMake(width, CGFLOAT_MAX)
               lineBreakMode:lineBreakMode].height;
@@ -55,6 +66,13 @@ NI_FIX_CATEGORY_BUG(NSStringNimbusCore)
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+/**
+ * Deprecated. Use ni_queryContentsUsingEncoding instead.
+ */
+- (NSDictionary*)queryContentsUsingEncoding:(NSStringEncoding)encoding {
+  return [self ni_queryContentsUsingEncoding:encoding];
+}
+
 /**
  * Parses a URL query string into a dictionary where the values are arrays.
  *
@@ -65,7 +83,7 @@ NI_FIX_CATEGORY_BUG(NSStringNimbusCore)
  * in the query. Otherwise each object in the array with be an NSString corresponding to a value
  * in the query for that parameter.
  */
-- (NSDictionary*)queryContentsUsingEncoding:(NSStringEncoding)encoding {
+- (NSDictionary*)ni_queryContentsUsingEncoding:(NSStringEncoding)encoding {
   NSCharacterSet* delimiterSet = [NSCharacterSet characterSetWithCharactersInString:@"&;"];
   NSMutableDictionary* pairs = [NSMutableDictionary dictionary];
   NSScanner* scanner = [[NSScanner alloc] initWithString:self];
@@ -98,9 +116,16 @@ NI_FIX_CATEGORY_BUG(NSStringNimbusCore)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /**
- * Returns a string that has been escaped for use as a URL parameter.
+ * Deprecated. Use ni_stringByAddingPercentEscapesForURLParameter instead.
  */
 - (NSString *)stringByAddingPercentEscapesForURLParameter {
+  return [self ni_stringByAddingPercentEscapesForURLParameter];
+}
+
+/**
+ * Returns a string that has been escaped for use as a URL parameter.
+ */
+- (NSString *)ni_stringByAddingPercentEscapesForURLParameter {
   
   CFStringRef buffer = 
   CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
@@ -119,12 +144,19 @@ NI_FIX_CATEGORY_BUG(NSStringNimbusCore)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /**
- * Parses a URL, adds query parameters to its query, and re-encodes it as a new URL.
+ * Deprecated. Use ni_stringByAddingQueryDictionary instead.
  */
 - (NSString*)stringByAddingQueryDictionary:(NSDictionary*)query {
+  return [self ni_stringByAddingQueryDictionary:query];
+}
+
+/**
+ * Parses a URL, adds query parameters to its query, and re-encodes it as a new URL.
+ */
+- (NSString*)ni_stringByAddingQueryDictionary:(NSDictionary*)query {
   NSMutableArray* pairs = [NSMutableArray array];
   for (NSString* key in [query keyEnumerator]) {
-    NSString* value = [[query objectForKey:key] stringByAddingPercentEscapesForURLParameter];
+    NSString* value = [[query objectForKey:key] ni_stringByAddingPercentEscapesForURLParameter];
     NSString* pair = [NSString stringWithFormat:@"%@=%@", key, value];
     [pairs addObject:pair];
   }
@@ -140,6 +172,13 @@ NI_FIX_CATEGORY_BUG(NSStringNimbusCore)
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+/**
+ * Deprecated. Use ni_versionStringCompare instead.
+ */
+- (NSComparisonResult)versionStringCompare:(NSString *)other {
+  return [self ni_versionStringCompare:other];
+}
+
 /**
  * Compares two strings expressing software versions.
  *
@@ -176,7 +215,7 @@ NI_FIX_CATEGORY_BUG(NSStringNimbusCore)
  * </pre>
  * @endhtmlonly
  */
-- (NSComparisonResult)versionStringCompare:(NSString *)other {
+- (NSComparisonResult)ni_versionStringCompare:(NSString *)other {
   NSArray *oneComponents = [self componentsSeparatedByString:@"a"];
   NSArray *twoComponents = [other componentsSeparatedByString:@"a"];
 
@@ -213,22 +252,36 @@ NI_FIX_CATEGORY_BUG(NSStringNimbusCore)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /**
+ * Deprecated. Use ni_md5Hash instead.
+ */
+- (NSString*)md5Hash {
+  return [self ni_md5Hash];
+}
+
+/**
  * Calculate the md5 hash using CC_MD5.
  *
  * @returns md5 hash of this string.
  */
-- (NSString*)md5Hash {
+- (NSString*)ni_md5Hash {
   return NIMD5HashFromData([self dataUsingEncoding:NSUTF8StringEncoding]);
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /**
+ * Deprecated. Use ni_sha1Hash instead.
+ */
+- (NSString*)sha1Hash {
+  return [self ni_sha1Hash];
+}
+
+/**
  * Calculate the SHA1 hash using CommonCrypto CC_SHA1.
  *
  * @returns SHA1 hash of this string.
  */
-- (NSString*)sha1Hash {
+- (NSString*)ni_sha1Hash {
   return NISHA1HashFromData([self dataUsingEncoding:NSUTF8StringEncoding]);
 }
 

--- a/src/core/unittests/NICoreAdditionTests.m
+++ b/src/core/unittests/NICoreAdditionTests.m
@@ -41,65 +41,65 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)testNSString_queryContentsUsingEncoding {
+- (void)testNSString_ni_queryContentsUsingEncoding {
 	NSDictionary* query;
 
-	query = [@"" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([query count] == 0, @"Query: %@", query);
 
-	query = [@"q" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:[NSArray arrayWithObject:[NSNull null]]],
                @"Query: %@", query);
 
-	query = [@"q=" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:[NSArray arrayWithObject:@""]],
                @"Query: %@", query);
 
-	query = [@"q=three20" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=three20" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:[NSArray arrayWithObject:@"three20"]],
                @"Query: %@", query);
 
-	query = [@"q=three20%20github" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=three20%20github" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:[NSArray arrayWithObject:@"three20 github"]],
                @"Query: %@", query);
 
-	query = [@"q=three20&hl=en" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=three20&hl=en" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:[NSArray arrayWithObject:@"three20"]],
                @"Query: %@", query);
 	STAssertTrue([[query objectForKey:@"hl"] isEqual:[NSArray arrayWithObject:@"en"]],
                @"Query: %@", query);
 
-	query = [@"q=three20&hl=" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=three20&hl=" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:[NSArray arrayWithObject:@"three20"]],
                @"Query: %@", query);
 	STAssertTrue([[query objectForKey:@"hl"] isEqual:[NSArray arrayWithObject:@""]],
                @"Query: %@", query);
 
-	query = [@"q=&&hl=" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=&&hl=" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:[NSArray arrayWithObject:@""]],
                @"Query: %@", query);
 	STAssertTrue([[query objectForKey:@"hl"] isEqual:[NSArray arrayWithObject:@""]],
                @"Query: %@", query);
 
-	query = [@"q=three20=repo&hl=en" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=three20=repo&hl=en" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertNil([query objectForKey:@"q"], @"Query: %@", query);
 	STAssertTrue([[query objectForKey:@"hl"] isEqual:[NSArray arrayWithObject:@"en"]],
                @"Query: %@", query);
 
-	query = [@"&&" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"&&" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	STAssertTrue([query count] == 0, @"Query: %@", query);
 
-	query = [@"q=foo&q=three20" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=foo&q=three20" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	NSArray* qArr = [NSArray arrayWithObjects:@"foo", @"three20", nil];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:qArr], @"Query: %@", query);
 
-	query = [@"q=foo&q=three20&hl=en" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=foo&q=three20&hl=en" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	qArr = [NSArray arrayWithObjects:@"foo", @"three20", nil];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:qArr], @"Query: %@", query);
 	STAssertTrue([[query objectForKey:@"hl"] isEqual:[NSArray arrayWithObject:@"en"]],
                @"Query: %@", query);
 
-	query = [@"q=foo&q=three20&hl=en&g" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q=foo&q=three20&hl=en&g" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	qArr = [NSArray arrayWithObjects:@"foo", @"three20", nil];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:qArr], @"Query: %@", query);
 	STAssertTrue([[query objectForKey:@"hl"] isEqual:[NSArray arrayWithObject:@"en"]],
@@ -107,7 +107,7 @@
 	STAssertTrue([[query objectForKey:@"g"] isEqual:[NSArray arrayWithObject:[NSNull null]]],
                @"Query: %@", query);
 
-	query = [@"q&q=three20&hl=en&g" queryContentsUsingEncoding:NSUTF8StringEncoding];
+	query = [@"q&q=three20&hl=en&g" ni_queryContentsUsingEncoding:NSUTF8StringEncoding];
 	qArr = [NSArray arrayWithObjects:[NSNull null], @"three20", nil];
 	STAssertTrue([[query objectForKey:@"q"] isEqual:qArr], @"Query: %@", query);
 	STAssertTrue([[query objectForKey:@"hl"] isEqual:[NSArray arrayWithObject:@"en"]],
@@ -116,15 +116,15 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)testNSString_stringByAddingQueryDictionary {
+- (void)testNSString_ni_stringByAddingQueryDictionary {
   NSString* baseUrl = @"http://google.com/search";
-  STAssertTrue([[baseUrl stringByAddingQueryDictionary:nil] isEqualToString:
+  STAssertTrue([[baseUrl ni_stringByAddingQueryDictionary:nil] isEqualToString:
                 [baseUrl stringByAppendingString:@"?"]], @"Empty dictionary fail.");
 
-  STAssertTrue([[baseUrl stringByAddingQueryDictionary:[NSDictionary dictionary]] isEqualToString:
+  STAssertTrue([[baseUrl ni_stringByAddingQueryDictionary:[NSDictionary dictionary]] isEqualToString:
                 [baseUrl stringByAppendingString:@"?"]], @"Empty dictionary fail.");
 
-  STAssertTrue([[baseUrl stringByAddingQueryDictionary:[NSDictionary
+  STAssertTrue([[baseUrl ni_stringByAddingQueryDictionary:[NSDictionary
                                                         dictionaryWithObject:@"three20"
                                                         forKey:@"q"]] isEqualToString:
                 [baseUrl stringByAppendingString:@"?q=three20"]], @"Single parameter fail.");
@@ -134,41 +134,41 @@
                          @"three20", @"q",
                          @"en",      @"hl",
                          nil];
-  NSString* baseUrlWithQuery = [baseUrl stringByAddingQueryDictionary:query];
+  NSString* baseUrlWithQuery = [baseUrl ni_stringByAddingQueryDictionary:query];
   STAssertTrue([baseUrlWithQuery isEqualToString:[baseUrl
                                                   stringByAppendingString:@"?hl=en&q=three20"]]
                || [baseUrlWithQuery isEqualToString:[baseUrl
                                                      stringByAppendingString:@"?q=three20&hl=en"]],
                @"Additional query parameters not correct. %@",
-               [baseUrl stringByAddingQueryDictionary:query]);
+               [baseUrl ni_stringByAddingQueryDictionary:query]);
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)testNSString_versionStringCompare {
-  STAssertTrue([@"3.0"   versionStringCompare:@"3.0"]    == NSOrderedSame, @"same version");
-  STAssertTrue([@"3.0a2" versionStringCompare:@"3.0a2"]  == NSOrderedSame, @"same version alpha");
-  STAssertTrue([@"3.0"   versionStringCompare:@"2.5"]    == NSOrderedDescending, @"major no alpha");
-  STAssertTrue([@"3.1"   versionStringCompare:@"3.0"]    == NSOrderedDescending, @"minor no alpha");
-  STAssertTrue([@"3.0a1" versionStringCompare:@"3.0"]    == NSOrderedAscending, @"alpha-no alpha");
-  STAssertTrue([@"3.0a1" versionStringCompare:@"3.0a4"]  == NSOrderedAscending, @"alpha diff");
-  STAssertTrue([@"3.0a2" versionStringCompare:@"3.0a19"] == NSOrderedAscending, @"numeric alpha");
-  STAssertTrue([@"3.0a"  versionStringCompare:@"3.0a1"]  == NSOrderedAscending, @"empty alpha");
-  STAssertTrue([@"3.02"  versionStringCompare:@"3.03"]   == NSOrderedAscending, @"point diff");
-  STAssertTrue([@"3.0.2" versionStringCompare:@"3.0.3"]  == NSOrderedAscending, @"point diff");
+- (void)testNSString_ni_versionStringCompare {
+  STAssertTrue([@"3.0"   ni_versionStringCompare:@"3.0"]    == NSOrderedSame, @"same version");
+  STAssertTrue([@"3.0a2" ni_versionStringCompare:@"3.0a2"]  == NSOrderedSame, @"same version alpha");
+  STAssertTrue([@"3.0"   ni_versionStringCompare:@"2.5"]    == NSOrderedDescending, @"major no alpha");
+  STAssertTrue([@"3.1"   ni_versionStringCompare:@"3.0"]    == NSOrderedDescending, @"minor no alpha");
+  STAssertTrue([@"3.0a1" ni_versionStringCompare:@"3.0"]    == NSOrderedAscending, @"alpha-no alpha");
+  STAssertTrue([@"3.0a1" ni_versionStringCompare:@"3.0a4"]  == NSOrderedAscending, @"alpha diff");
+  STAssertTrue([@"3.0a2" ni_versionStringCompare:@"3.0a19"] == NSOrderedAscending, @"numeric alpha");
+  STAssertTrue([@"3.0a"  ni_versionStringCompare:@"3.0a1"]  == NSOrderedAscending, @"empty alpha");
+  STAssertTrue([@"3.02"  ni_versionStringCompare:@"3.03"]   == NSOrderedAscending, @"point diff");
+  STAssertTrue([@"3.0.2" ni_versionStringCompare:@"3.0.3"]  == NSOrderedAscending, @"point diff");
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)testNSString_md5Hash {
-  STAssertTrue([[@"nimbus" md5Hash] isEqualToString:@"0e78d66f33c484a3c3b36d69bd3114cf"],
+- (void)testNSString_ni_md5Hash {
+  STAssertTrue([[@"nimbus" ni_md5Hash] isEqualToString:@"0e78d66f33c484a3c3b36d69bd3114cf"],
                @"MD5 hashes don't match.");
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)testNSString_sha1Hash {
-  STAssertTrue([[@"nimbus" sha1Hash] isEqualToString:@"c1b42d95fd18ad8a56d4fd7bbb4105952620d857"],
+- (void)testNSString_ni_sha1Hash {
+  STAssertTrue([[@"nimbus" ni_sha1Hash] isEqualToString:@"c1b42d95fd18ad8a56d4fd7bbb4105952620d857"],
                @"SHA1 hashes don't match.");
 }
 

--- a/src/css/src/NIChameleonObserver.m
+++ b/src/css/src/NIChameleonObserver.m
@@ -194,7 +194,7 @@ NSString* const NIJSONDidChangeNameKey = @"NIJSONNameKey";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (NSString *)pathFromPath:(NSString *)path {
-  return [path md5Hash];
+  return [path ni_md5Hash];
 }
 
 

--- a/src/interapp/src/NIInterapp.m
+++ b/src/interapp/src/NIInterapp.m
@@ -188,7 +188,7 @@ static NSString* const sGoogleMapsScheme = @"comgooglemaps:";
 
   NSString* urlPath = [NSString stringWithFormat:
                          @"?q=%@@%f,%f",
-                         [title stringByAddingPercentEscapesForURLParameter], location.latitude, location.longitude];
+                         [title ni_stringByAddingPercentEscapesForURLParameter], location.latitude, location.longitude];
   return [NIInterapp openBestGoogleMapUrl:urlPath];
 
 }
@@ -253,7 +253,7 @@ static NSString* const sGoogleMapsScheme = @"comgooglemaps:";
 + (BOOL)googleMapWithQuery:(NSString *)query {
   NSString* urlPath = [NSString stringWithFormat:
                        @"?q=%@",
-                       [query stringByAddingPercentEscapesForURLParameter]];
+                       [query ni_stringByAddingPercentEscapesForURLParameter]];
   return [NIInterapp openBestGoogleMapUrl:urlPath ];
 }
 
@@ -323,7 +323,7 @@ static NSString* const sMailScheme = @"mailto:";
   NSString* urlPath = sMailScheme;
 
   if (NIIsStringWithAnyText(invocation.recipient)) {
-    urlPath = [urlPath stringByAppendingString:[invocation.recipient stringByAddingPercentEscapesForURLParameter]];
+    urlPath = [urlPath stringByAppendingString:[invocation.recipient ni_stringByAddingPercentEscapesForURLParameter]];
   }
 
   if (NIIsStringWithAnyText(invocation.cc)) {
@@ -339,7 +339,7 @@ static NSString* const sMailScheme = @"mailto:";
     [parameters setObject:invocation.body forKey:@"body"];
   }
 
-  urlPath = [urlPath stringByAddingQueryDictionary:parameters];
+  urlPath = [urlPath ni_stringByAddingQueryDictionary:parameters];
 
   return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlPath]];
 }
@@ -458,7 +458,7 @@ static NSString* const sTwitterScheme = @"twitter:";
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 + (BOOL)twitterWithMessage:(NSString *)message {
   NSString* urlPath = [sTwitterScheme stringByAppendingFormat:@"//post?message=%@",
-                       [message stringByAddingPercentEscapesForURLParameter]];
+                       [message ni_stringByAddingPercentEscapesForURLParameter]];
   return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlPath]];
 }
 
@@ -466,7 +466,7 @@ static NSString* const sTwitterScheme = @"twitter:";
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 + (BOOL)twitterProfileForUsername:(NSString *)username {
   NSString* urlPath = [sTwitterScheme stringByAppendingFormat:@"//user?screen_name=%@",
-                       [username stringByAddingPercentEscapesForURLParameter]];
+                       [username ni_stringByAddingPercentEscapesForURLParameter]];
   return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlPath]];
 }
 
@@ -579,7 +579,7 @@ static NSString* const sInstagramScheme = @"instagram:";
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 + (BOOL)instagramProfileForUsername:(NSString *)username {
   NSString* urlPath = [sInstagramScheme stringByAppendingFormat:@"//user?username=%@",
-                       [username stringByAddingPercentEscapesForURLParameter]];
+                       [username ni_stringByAddingPercentEscapesForURLParameter]];
   return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlPath]];
 }
 


### PR DESCRIPTION
Adds a prefix to avoid risking overriding future iOS methods. Keeps non-prefixed methods, but marks them as deprecated.
