### PR TITLE
Overwrite webview toolbar

### DIFF
--- a/src/webcontroller/src/NIWebController.h
+++ b/src/webcontroller/src/NIWebController.h
@@ -157,6 +157,16 @@
 
 /** @name Accessing the Toolbar */
 
+
+/**
+ * The initialization of the toolbar.
+ *
+ * Adds the option to overwrite the toolbar initialization called by loadView function
+ * This is needed to add additional buttons
+ *
+ *      @fn NIWebController::initToolbar
+ */
+
 /**
  * The visibility of the toolbar.
  *

--- a/src/webcontroller/src/NIWebController.m
+++ b/src/webcontroller/src/NIWebController.m
@@ -204,8 +204,8 @@
   }
 }
 
-
-- (void)initToolBar {
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)initToolbar {
     CGRect bounds = self.view.bounds;
     
     CGFloat toolbarHeight = NIToolbarHeightForOrientation(NIInterfaceOrientation());
@@ -289,7 +289,7 @@
 - (void)loadView {
   [super loadView];
     
-  [self initToolBar];
+  [self initToolbar];
 
 
   self.webView = [[UIWebView alloc] initWithFrame:CGRectZero];


### PR DESCRIPTION
Needed to add additional buttons to NIWebView.

Moved the toolbar init to a dedicated function to overwrite the function when subclassing NIWebView.
