### PR TITLE
[NIOverview] Make inspector print object's address

### DIFF
--- a/src/overview/src/NIOverviewPageView.m
+++ b/src/overview/src/NIOverviewPageView.m
@@ -964,11 +964,17 @@ static NIViewInspectionView *visibleInspectionView = nil;
       offset.y += kAvoidedTopHeight;
     }
 
+    NSString *responder = [NSString stringWithFromat:@"%@ (%p)",
+                           NSStringFromClass([interactingView_ class]),
+                           interactingView_];
     offset.y += [self drawTitle:@"Responder: "
-                          value:NSStringFromClass([interactingView_ class])
+                          value:responder
                         atPoint:offset];
+    NSString *touched = [NSString stringWithFromat:@"%@ (%p)",
+                         NSStringFromClass([touchedView_ class]),
+                         touchedView_];
     offset.y += [self drawTitle:@"Touched: "
-                          value:NSStringFromClass([touchedView_ class])
+                          value:touched
                         atPoint:offset];
     offset.y += [self drawTitle:@"Frame: "
                           value:NSStringFromCGRect(touchedView_.frame)


### PR DESCRIPTION
Print out object's address to make debugging easier.
