### PR TITLE
Fixed get incorrect reuse identifier in PagingScrollView sample

### DIFF
--- a/examples/catalog/Catalog/SamplePageView.m
+++ b/examples/catalog/Catalog/SamplePageView.m
@@ -31,6 +31,8 @@
     _label.backgroundColor = [UIColor clearColor];
     
     [self addSubview:_label];
+      
+    self.reuseIdentifier = reuseIdentifier;
   }
   return self;
 }


### PR DESCRIPTION
In dequeueReusableViewWithIdentifier, SamplePageView instance has been initialized with reuse identifier, but it had not been assigned reuseIdentifier, so it used the name of page view class instead of reuseIdentifier while recycleView. It takes SamplePageView always created new instance instead of reuse and allocation memory issue found in #444.
