### PR TITLE
Fix NIWebController view frame under iOS7

### DIFF
--- a/src/webcontroller/src/NIWebController.m
+++ b/src/webcontroller/src/NIWebController.m
@@ -74,6 +74,11 @@
 - (id)initWithRequest:(NSURLRequest *)request {
   if ((self = [super initWithNibName:nil bundle:nil])) {
     self.hidesBottomBarWhenPushed = YES;
+
+    if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
+      self.edgesForExtendedLayout = UIRectEdgeNone;
+    }
+
     [self openRequest:request];
   }
   return self;


### PR DESCRIPTION
This is a simple fix for #465.

Default value is `UIExtendedEdgeAll`.
