### PR TITLE
Remove tableView delegates when dealloc.

### DIFF
--- a/src/networkcontrollers/src/NINetworkTableViewController.m
+++ b/src/networkcontrollers/src/NINetworkTableViewController.m
@@ -41,6 +41,12 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)dealloc {
+  _tableView.delegate = nil;
+  _tableView.dataSource = nil;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)initWithStyle:(UITableViewStyle)style activityIndicatorStyle:(UIActivityIndicatorViewStyle)activityIndicatorStyle {
   if ((self = [super initWithNibName:nil bundle:nil])) {
     self.tableViewStyle = style;


### PR DESCRIPTION
We recently saw several `EXEC_BAD_ACCESS` crashes related to `UITableView` delegates, and resolved those issues by manually setting delegates to `nil`.

Surprisingly, those `UITableView` delegates are not `weak` properties but `assign`. Ref:

``` ObjC
@property (nonatomic, assign)   id <UITableViewDataSource> dataSource;
@property (nonatomic, assign)   id <UITableViewDelegate>   delegate;
```
