### PR TITLE
NIAttributedLabel: Disable actionsheet for non-Internet URL’s

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1140,6 +1140,13 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
     UIActionSheet* actionSheet = [self actionSheetForResult:self.actionSheetLink];
 
     BOOL shouldPresent = YES;
+    
+    NSString *scheme=self.touchedLink.URL.scheme;
+    if(!([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"] || [scheme isEqualToString:@"ftp"])) {
+      //URL Scheme is not an Internet address, we must not show actionsheet
+      shouldPresent=NO;
+    }
+    
     if ([self.delegate respondsToSelector:@selector(attributedLabel:shouldPresentActionSheet:withTextCheckingResult:atPoint:)]) {
       // Give the delegate the opportunity to not show the action sheet or to present their own.
       shouldPresent = [self.delegate attributedLabel:self shouldPresentActionSheet:actionSheet withTextCheckingResult:self.touchedLink atPoint:self.touchPoint];


### PR DESCRIPTION
It was a problem that I saw when I was using - addLink:range: to create some internal links for in-app navigation.

I use some special URL scheme to distinguish internet URL's (Like we used to do in Three20, tt://someThing)

But NIAttributedLabel does not perform any checks before showing actionsheet (Open in Safari etc.)

For in-app links, the actionsheet firstly innecessary, secondly we would not want the user to see our internal URL (which is generally ugly)

This commits adds a check that performs a control. If the URL is an Internet URL (HTTP(s) or FTP). If not, does not show actionsheet.
