### PR TITLE
Set the writing direction of the image placeholder string to LTR because image is drawn in LTR manner.

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1246,8 +1246,20 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString *attributedS
       unichar objectReplacementChar = 0xFFFC;
       NSString *objectReplacementString = [NSString stringWithCharacters:&objectReplacementChar length:1];
       NSMutableAttributedString* space = [[NSMutableAttributedString alloc] initWithString:objectReplacementString];
-      CFAttributedStringSetAttribute((__bridge CFMutableAttributedStringRef)space, CFRangeMake(0, 1), kCTRunDelegateAttributeName, delegate);
+
+      CFRange range = CFRangeMake(0, 1);
+      CFMutableAttributedStringRef spaceString =
+          (__bridge_retained CFMutableAttributedStringRef)space;
+      CFAttributedStringSetAttribute(spaceString, range, kCTRunDelegateAttributeName, delegate);
+      // Explicitly set the writing direction of this string to LTR, because in 'drawImages' we draw
+      // for LTR by drawing at offset to offset + width vs to offset - width as you would for RTL.
+      CFAttributedStringSetAttribute(spaceString,
+                                     range,
+                                     kCTWritingDirectionAttributeName,
+                                     (__bridge CFArrayRef)@[@(kCTWritingDirectionLeftToRight)]);
       CFRelease(delegate);
+      CFRelease(spaceString);
+
       [attributedString insertAttributedString:space atIndex:labelImage.index];
     }
   }


### PR DESCRIPTION
For Right-to-Left text: In drawImages, we obtain the offset, and since the string is RTL, the
offset returned is a RTL offset with the idea the next code will be
drawing in RTL directionality. Whereas the code draws the image in LTR
layout, so I explicitly set the writing direction of the image
placeholder string to LTR (as we draw the image LTR) and thus the
correct offset is returned allowing us to draw LTR and the image is
shown correctly. This shouldn't break LTR clients, as we are just
setting the writing directionality to that.
