### PR TITLE
Restore preexisting designated initializer contracts for cell objects.

### DIFF
--- a/examples/photos/NetworkPhotoAlbums/NetworkPhotoAlbum.xcodeproj/project.pbxproj
+++ b/examples/photos/NetworkPhotoAlbums/NetworkPhotoAlbum.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		66EAC7DB13D2A77D00BDFF34 /* NimbusPhotos.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = NimbusPhotos.bundle; path = ../../../src/photos/resources/NimbusPhotos.bundle; sourceTree = SOURCE_ROOT; };
 		66F27D5B145B7DF500AFCA08 /* NIViewRecycler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NIViewRecycler.h; path = ../../../src/core/src/NIViewRecycler.h; sourceTree = "<group>"; };
 		66F27D5C145B7DF500AFCA08 /* NIViewRecycler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NIViewRecycler.m; path = ../../../src/core/src/NIViewRecycler.m; sourceTree = "<group>"; };
+		D526CF2818B6CC7E00991F7A /* NICellFactory+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NICellFactory+Private.h"; path = "../../../src/models/src/NICellFactory+Private.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -407,6 +408,7 @@
 				669F0D0D158002DD0069B972 /* NIFormCellCatalog.h */,
 				669F0D0E158002DD0069B972 /* NIFormCellCatalog.m */,
 				669F0D0F158002DD0069B972 /* NICellFactory.h */,
+				D526CF2818B6CC7E00991F7A /* NICellFactory+Private.h */,
 				669F0D10158002DD0069B972 /* NICellFactory.m */,
 				669F0D11158002DD0069B972 /* NIRadioGroup.h */,
 				669F0D12158002DD0069B972 /* NIRadioGroup.m */,

--- a/src/models/src/NICellCatalog.h
+++ b/src/models/src/NICellCatalog.h
@@ -42,9 +42,9 @@ typedef CGFloat (^NICellDrawRectBlock)(CGRect rect, id object, UITableViewCell* 
  */
 @interface NITitleCellObject : NICellObject
 // Designated initializer.
-- (id)initWithTitle:(NSString *)title image:(UIImage *)image cellClass:(Class)cellClass userInfo:(id)userInfo;
 - (id)initWithTitle:(NSString *)title image:(UIImage *)image;
 - (id)initWithTitle:(NSString *)title;
+- (id)initWithTitle:(NSString *)title image:(UIImage *)image cellClass:(Class)cellClass userInfo:(id)userInfo;
 + (id)objectWithTitle:(NSString *)title image:(UIImage *)image;
 + (id)objectWithTitle:(NSString *)title;
 @property (nonatomic, copy) NSString* title;
@@ -62,10 +62,10 @@ typedef CGFloat (^NICellDrawRectBlock)(CGRect rect, id object, UITableViewCell* 
  */
 @interface NISubtitleCellObject : NITitleCellObject
 // Designated initializer.
-- (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image cellClass:(Class)cellClass userInfo:(id)userInfo;
 - (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image;
-+ (id)objectWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image;
 - (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle;
+- (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image cellClass:(Class)cellClass userInfo:(id)userInfo;
++ (id)objectWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image;
 + (id)objectWithTitle:(NSString *)title subtitle:(NSString *)subtitle;
 @property (nonatomic, copy) NSString* subtitle;
 @property (nonatomic, assign) UITableViewCellStyle cellStyle;

--- a/src/models/src/NICellCatalog.m
+++ b/src/models/src/NICellCatalog.m
@@ -15,6 +15,7 @@
 //
 
 #import "NICellCatalog.h"
+#import "NICellFactory+Private.h"
 
 #import "NimbusCore.h"
 
@@ -44,9 +45,9 @@
 @implementation NITitleCellObject
 
 - (id)initWithTitle:(NSString *)title image:(UIImage *)image cellClass:(Class)cellClass userInfo:(id)userInfo {
-  if ((self = [super initWithCellClass:cellClass userInfo:userInfo])) {
-    _title = [title copy];
-    _image = image;
+  if ((self = [self initWithTitle:title image:image])) {
+    self.cellClass = cellClass;
+    self.userInfo = userInfo;
   }
   return self;
 }
@@ -56,15 +57,19 @@
 }
 
 - (id)initWithTitle:(NSString *)title image:(UIImage *)image {
-  return [self initWithTitle:title image:image cellClass:[NITextCell class] userInfo:nil];
+  if ((self = [super initWithCellClass:[NITextCell class] userInfo:nil])) {
+    _title = [title copy];
+    _image = image;
+  }
+  return self;
 }
 
 - (id)initWithTitle:(NSString *)title {
-  return [self initWithTitle:title image:nil cellClass:[NITextCell class] userInfo:nil];
+  return [self initWithTitle:title image:nil];
 }
 
 - (id)init {
-  return [self initWithTitle:nil image:nil cellClass:[NITextCell class] userInfo:nil];
+  return [self initWithTitle:nil image:nil];
 }
 
 + (id)objectWithTitle:(NSString *)title image:(UIImage *)image {
@@ -81,27 +86,31 @@
 @implementation NISubtitleCellObject
 
 - (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image cellClass:(Class)cellClass userInfo:(id)userInfo {
-  if ((self = [super initWithTitle:title image:image cellClass:cellClass userInfo:userInfo])) {
+  if ((self = [self initWithTitle:title subtitle:subtitle image:image])) {
+    self.cellClass = cellClass;
+    self.userInfo = userInfo;
+  }
+  return self;
+}
+
+- (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image {
+  if ((self = [super initWithTitle:title image:image])) {
     _subtitle = [subtitle copy];
     _cellStyle = UITableViewCellStyleSubtitle;
   }
   return self;
 }
 
-- (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image {
-  return [self initWithTitle:title subtitle:subtitle image:image cellClass:[NITextCell class] userInfo:nil];
-}
-
 - (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle {
-  return [self initWithTitle:title subtitle:subtitle image:nil cellClass:[NITextCell class] userInfo:nil];
+  return [self initWithTitle:title subtitle:subtitle image:nil];
 }
 
 - (id)initWithTitle:(NSString *)title image:(UIImage *)image {
-  return [self initWithTitle:title subtitle:nil image:image cellClass:[NITextCell class] userInfo:nil];
+  return [self initWithTitle:title subtitle:nil image:image];
 }
 
 - (id)init {
-  return [self initWithTitle:nil subtitle:nil image:nil cellClass:[NITextCell class] userInfo:nil];
+  return [self initWithTitle:nil subtitle:nil image:nil];
 }
 
 + (id)objectWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image {

--- a/src/models/src/NICellFactory+Private.h
+++ b/src/models/src/NICellFactory+Private.h
@@ -1,0 +1,25 @@
+//
+// Copyright 2011-2014 NimbusKit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "NICellFactory.h"
+
+// Private classes for use in Nimbus.
+@interface NICellObject ()
+
+// A property to change the cell class of this cell object.
+@property(nonatomic, assign) Class cellClass;
+
+@end

--- a/src/models/src/NICellFactory.m
+++ b/src/models/src/NICellFactory.m
@@ -15,6 +15,7 @@
 //
 
 #import "NICellFactory.h"
+#import "NICellFactory+Private.h"
 
 #import "NimbusCore.h"
 
@@ -191,10 +192,6 @@
 
 @end
 
-
-@interface NICellObject()
-@property (nonatomic, assign) Class cellClass;
-@end
 
 
 @implementation NICellObject


### PR DESCRIPTION
Calls to any initializer other than initWithTitle:image: or initWithTitle:subtitle:image:
used to traverse subclass overrides of those initializers. The designated initializer chain
introduced in commit d8a69614901e95ff9736938a2df6c8829e10e43e makes more intuitive sense but
violates the previous contract provided to all subclass overrides of the previous designated
initializers and potentially introduces a profusion of cell object initialization errors.
