### PR TITLE
Fixed -Wundef warnings

### DIFF
--- a/src/core/src/NISDKAvailability.h
+++ b/src/core/src/NISDKAvailability.h
@@ -173,7 +173,7 @@
 #define kCFCoreFoundationVersionNumber_iOS_6_1 793.00
 #endif
 
-#if __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -235,7 +235,7 @@ Class NIUIPopoverControllerClass(void) __NI_DEPRECATED_METHOD;
  */
 Class NIUITapGestureRecognizerClass(void) __NI_DEPRECATED_METHOD;
 
-#if __cplusplus
+#if defined(__cplusplus)
 } // extern "C"
 #endif
 

--- a/src/models/src/NIRadioGroupController.m
+++ b/src/models/src/NIRadioGroupController.m
@@ -18,6 +18,7 @@
 
 #import "NICellFactory.h"
 #import "NIRadioGroup.h"
+#import "NISDKAvailability.h"
 #import "NITableViewModel.h"
 
 #import "NIDebuggingTools.h"


### PR DESCRIPTION
Allows external projects that want to define -Wundef to compile, and fixes a bug in NIRadioGroupController.m that was caught with -Wundef turned on.
