### PR TITLE
[models] Add a unit test to models to validate subclassed cell object initialization

### DIFF
--- a/src/Nimbus.xcodeproj/project.pbxproj
+++ b/src/Nimbus.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		C7BBC71116DE66BD00833DC9 /* media-rulesets.css in Resources */ = {isa = PBXBuildFile; fileRef = C7BBC71016DE66BD00833DC9 /* media-rulesets.css */; };
 		D509DDDF18B53AE500895428 /* NIPageView.h in Headers */ = {isa = PBXBuildFile; fileRef = D509DDDD18B53AE500895428 /* NIPageView.h */; };
 		D509DDE018B53AE500895428 /* NIPageView.m in Sources */ = {isa = PBXBuildFile; fileRef = D509DDDE18B53AE500895428 /* NIPageView.m */; };
+		D526CF4B18B826A600991F7A /* NICellCatalogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D526CF4A18B826A600991F7A /* NICellCatalogTests.m */; };
 		DB3A231713FD4B8E00614220 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66A03C1A13E6E85E00B514F3 /* SenTestingKit.framework */; };
 		DB3A231913FD4B8E00614220 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66A03C0C13E6E85E00B514F3 /* Foundation.framework */; };
 		DB3A231D13FD4B8E00614220 /* libNimbusAttributedLabel.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3A230913FD4B8E00614220 /* libNimbusAttributedLabel.a */; };
@@ -987,6 +988,7 @@
 		C7BBC71016DE66BD00833DC9 /* media-rulesets.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = "media-rulesets.css"; path = "css/unittests/media-rulesets.css"; sourceTree = SOURCE_ROOT; };
 		D509DDDD18B53AE500895428 /* NIPageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NIPageView.h; sourceTree = "<group>"; };
 		D509DDDE18B53AE500895428 /* NIPageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NIPageView.m; sourceTree = "<group>"; };
+		D526CF4A18B826A600991F7A /* NICellCatalogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NICellCatalogTests.m; sourceTree = "<group>"; };
 		DB3A230913FD4B8E00614220 /* libNimbusAttributedLabel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libNimbusAttributedLabel.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB3A231613FD4B8E00614220 /* NimbusAttributedLabelTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbusAttributedLabelTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB3A233213FD4BE500614220 /* NIAttributedLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NIAttributedLabel.h; sourceTree = "<group>"; };
@@ -2103,6 +2105,7 @@
 				6623EB6C1402ECE400E0E61A /* NITableViewModelTests.m */,
 				66D2E54615D9503100281511 /* NIMutableTableViewModelTests.m */,
 				6672DAB415B87E4B00DFE81F /* NICellFactoryTests.m */,
+				D526CF4A18B826A600991F7A /* NICellCatalogTests.m */,
 			);
 			name = unittests;
 			path = models/unittests;
@@ -3537,6 +3540,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D526CF4B18B826A600991F7A /* NICellCatalogTests.m in Sources */,
 				6623EB6D1402ECE400E0E61A /* NITableViewModelTests.m in Sources */,
 				6672DAB515B87E4B00DFE81F /* NICellFactoryTests.m in Sources */,
 				66D2E54715D9503100281511 /* NIMutableTableViewModelTests.m in Sources */,

--- a/src/models/unittests/NICellCatalogTests.m
+++ b/src/models/unittests/NICellCatalogTests.m
@@ -1,0 +1,68 @@
+//
+// Copyright 2011-2014 NimbusKit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+#import "NimbusCore.h"
+#import "NimbusModels.h"
+
+@interface NICellCatalogTests : SenTestCase
+@end
+
+@interface TestTitleCellObject : NITitleCellObject
+@property (nonatomic, assign) BOOL designatedInitializerWasExecuted;
+@end
+
+@interface TestSubtitleCellObject : NISubtitleCellObject
+@property (nonatomic, assign) BOOL designatedInitializerWasExecuted;
+@end
+
+@implementation NICellCatalogTests
+
+- (void)testCellObjectSubclassInitialization {
+  TestTitleCellObject *titleCellObject = [[TestTitleCellObject alloc] initWithTitle:@"Title"];
+  STAssertTrue(titleCellObject.designatedInitializerWasExecuted,
+               @"%@'s designated initializer override did not run.", [titleCellObject class]);
+  TestSubtitleCellObject *subtitleCellObject = [[TestSubtitleCellObject alloc] initWithTitle:@"Title"];
+  STAssertTrue(subtitleCellObject.designatedInitializerWasExecuted,
+               @"%@'s designated initializer override did not run.", [subtitleCellObject class]);
+}
+
+@end
+
+@implementation TestTitleCellObject
+
+- (id)initWithTitle:(NSString *)title image:(UIImage *)image {
+  self = [super initWithTitle:title image:image];
+  if (self) {
+    _designatedInitializerWasExecuted = YES;
+  }
+  return self;
+}
+
+@end
+
+@implementation TestSubtitleCellObject
+
+- (id)initWithTitle:(NSString *)title subtitle:(NSString *)subtitle image:(UIImage *)image {
+  self = [super initWithTitle:title subtitle:subtitle image:image];
+  if (self) {
+    _designatedInitializerWasExecuted = YES;
+  }
+  return self;
+}
+
+@end


### PR DESCRIPTION
Create a new unit test that captures the current designated initializer contract between NITitleCellObject/NISubtitleCellObject and their respective subclasses.
