### PR TITLE
Allow NICellbackground subclasses to override cache key and background tag for cell backgrounds.

### DIFF
--- a/src/models/src/NICellBackgrounds.h
+++ b/src/models/src/NICellBackgrounds.h
@@ -59,6 +59,9 @@ typedef enum {
 - (UIImage *)imageForFirst:(BOOL)first last:(BOOL)last highlighted:(BOOL)highlighted; // Default: drawDivider: True
 - (UIImage *)imageForFirst:(BOOL)first last:(BOOL)last highlighted:(BOOL)highlighted drawDivider:(BOOL)drawDivider;
 
+- (id)cacheKeyForFirst:(BOOL)first last:(BOOL)last highlighted:(BOOL)highlighted drawDivider:(BOOL)drawDivider;
+- (NSInteger)backgroundTagForFirst:(BOOL)isFirst last:(BOOL)isLast drawDivider:(BOOL)drawDivider;
+
 @property (nonatomic, strong) UIColor* innerBackgroundColor; // Default: [UIColor whiteColor]
 @property (nonatomic, strong) NSMutableArray* highlightedInnerGradientColors; // Default: RGBCOLOR(53, 141, 245), RGBCOLOR(16, 93, 230)
 @property (nonatomic, assign) CGFloat shadowWidth; // Default: 4
@@ -82,3 +85,47 @@ typedef enum {
  * @returns A UIImage representing the given configuration.
  * @fn NIGroupedCellBackground::imageForFirst:last:highlighted:
  */
+
+/**
+ * Returns an image for use with the given cell configuration.
+ *
+ * The returned image is cached internally after the first request. Changing any of the display
+ * properties will invalidate the cached images.
+ *
+ *      @param first YES will round the top corners.
+ *      @param last  YES will round the bottom corners.
+ *      @param highlighed YES will fill the contents with the highlightedInnerGradientColors.
+ *      @param drawDivider YES will draw a divider between this and the next cell if necessary.
+ *      @returns A UIImage representing the given configuration.
+ *      @fn NIGroupedCellBackground::imageForFirst:last:highlighted:drawDivider:
+ */
+
+/**
+ * Returns a cache key for the images returned by imageForFirst:last:highlighted:drawDivider:
+ * Subclaseses that alter the behaviour of imageForFirst:last:highlighted:drawDivider: need to
+ * override this method such that different images will have different cache keys. In particular,
+ * this this will be necessary if the appearance of the image depends on anything other than the
+ * arguments to the imageForFirst:last:highlighted:drawDivider: method.
+ *
+ *      @param first YES if the image is for the first row in a section
+ *      @param last  YES if the image is for the last row in a section
+ *      @param highlighted YES if the image is for a highlighted cell
+ *      @param drawDivider YES if the image includes a divider
+ *      @returns A cache key for an image that matches the given parameters.
+ *      @fn NIGroupedCellBackground::cacheKeyForFirst:last:highlighted:drawDivider:
+ */
+
+/**
+ * Returns a tag for a cell's background image. This is used to prevent a cell's background
+ * image from being set again when it already has the correct image. Similar to the cache key,
+ * subclasses that alter the behaviour of imageForFirst:last:highlighted:drawDivider: need to
+ * override this method, if the appearance of the image depends on anything other than the
+ * arguments to the imageForFirst:last:highlighted:drawDivider: method.
+ * Note that the highlighted state is irrelevant to the background tag.
+ *
+ *      @param first YES if the image is for the first row in a section
+ *      @param last  YES if the image is for the last row in a section
+ *      @param drawDivider YES if the image includes a divider
+ *      @returns A tag for an image that matches the given parameters.
+ *      @fn NIGroupedCellBackground::backgroundTagForFirst:last:drawDivider:
+*/

--- a/src/models/src/NICellBackgrounds.m
+++ b/src/models/src/NICellBackgrounds.m
@@ -361,7 +361,7 @@ static const CGSize kCellImageSize = {44, 44};
   return [image resizableImageWithCapInsets:UIEdgeInsetsMake(capHeight, capWidth, capHeight, capWidth)];
 }
 
-- (id)_cacheKeyForFirst:(BOOL)first last:(BOOL)last highlighted:(BOOL)highlighted drawDivider:(BOOL)drawDivider {
+- (id)cacheKeyForFirst:(BOOL)first last:(BOOL)last highlighted:(BOOL)highlighted drawDivider:(BOOL)drawDivider {
   NSInteger flags = ((first ? 0x01 : 0)
                      | (last ? 0x02 : 0)
                      | (highlighted ? 0x04 : 0)
@@ -386,10 +386,7 @@ static const CGSize kCellImageSize = {44, 44};
     id<NIGroupedCellAppearance> groupedCell = (id<NIGroupedCellAppearance>)cell;
     drawDivider = [groupedCell drawsCellDivider];
   }
-  NSInteger backgroundTag = ((isFirst ? NIGroupedCellBackgroundFlagIsFirst : 0)
-                             | (isLast ? NIGroupedCellBackgroundFlagIsLast : 0)
-                             | NIGroupedCellBackgroundFlagInitialized
-                             | (drawDivider ? 0 : NIGroupedCellBackgroundFlagNoDivider));
+  NSInteger backgroundTag = [self backgroundTagForFirst:isFirst last:isLast drawDivider:drawDivider];
   if (cell.backgroundView.tag != backgroundTag) {
     cell.backgroundView = [[UIImageView alloc] initWithImage:[self imageForFirst:isFirst
                                                                             last:isLast
@@ -403,12 +400,20 @@ static const CGSize kCellImageSize = {44, 44};
   }
 }
 
+- (NSInteger)backgroundTagForFirst:(BOOL)isFirst last:(BOOL)isLast drawDivider:(BOOL)drawDivider {
+  NSInteger tag = ((isFirst ? NIGroupedCellBackgroundFlagIsFirst : 0)
+                   | (isLast ? NIGroupedCellBackgroundFlagIsLast : 0)
+                   | NIGroupedCellBackgroundFlagInitialized
+                   | (drawDivider ? 0 : NIGroupedCellBackgroundFlagNoDivider));
+  return tag;
+}
+
 - (UIImage *)imageForFirst:(BOOL)first last:(BOOL)last highlighted:(BOOL)highlighted {
   return [self imageForFirst:first last:last highlighted:highlighted drawDivider:YES];
 }
 
 - (UIImage *)imageForFirst:(BOOL)first last:(BOOL)last highlighted:(BOOL)highlighted drawDivider:(BOOL)drawDivider {
-  id cacheKey = [self _cacheKeyForFirst:first last:last highlighted:highlighted drawDivider:drawDivider];
+  id cacheKey = [self cacheKeyForFirst:first last:last highlighted:highlighted drawDivider:drawDivider];
   UIImage* image = [self.cachedImages objectForKey:cacheKey];
   if (nil == image) {
     image = [self _imageForFirst:first last:last highlighted:highlighted drawDivider:drawDivider];


### PR DESCRIPTION
Since we allow NICellBackground subclasses to override imageForFirst:last:highlighted:drawDivider:, this change allows subclasses to override the cacheKey and backgroundTag that the cell background uses.

This way the caching facility of imageForFirst:last:highlighted:drawDivider: can be used by subclasses that override that method but call super, or somehow cause the cell background image to be drawn differently in a way not captured by the arguments.
