### PR TITLE
Fixing bug where tableviews with clear backgrounds turn black on rotation

### DIFF
--- a/src/core/src/NISnapshotRotation.m
+++ b/src/core/src/NISnapshotRotation.m
@@ -124,7 +124,7 @@ UIImageView* NISnapshotViewOfViewWithTransparency(UIView* view) {
   }
 
   self.frameBeforeRotation = rotationView.frame;
-  self.snapshotViewBeforeRotation = NISnapshotViewOfView(rotationView);
+  self.snapshotViewBeforeRotation = NISnapshotViewOfViewWithTransparency(rotationView);
   [containerView insertSubview:self.snapshotViewBeforeRotation aboveSubview:rotationView];
 }
 
@@ -146,7 +146,7 @@ UIImageView* NISnapshotViewOfViewWithTransparency(UIView* view) {
   
   [UIView setAnimationsEnabled:NO];
   
-  self.snapshotViewAfterRotation = NISnapshotViewOfView(rotationView);
+  self.snapshotViewAfterRotation = NISnapshotViewOfViewWithTransparency(rotationView);
   // Set the new frame while maintaining the old frame's height.
   self.snapshotViewAfterRotation.frame = CGRectMake(self.frameBeforeRotation.origin.x,
                                                     self.frameBeforeRotation.origin.y,


### PR DESCRIPTION
Changing how Nimbus does table snapshots so that if a tableview have a clear background, on a rotation, it does not just assume that the proper background is black.
