### PR TITLE
Fix up NIAction's class traversal when resolving actions for a subclass

### DIFF
--- a/src/core/src/NIActions.m
+++ b/src/core/src/NIActions.m
@@ -183,7 +183,7 @@
       // We want to find the lowest node in the class hierarchy so that we pick the lowest ancestor
       // in the hierarchy tree.
       if ([keyClass isSubclassOfClass:class]
-          && (nil == superClass || [keyClass isSubclassOfClass:superClass])) {
+          && (nil == superClass || [class isSubclassOfClass:superClass])) {
         superClass = class;
       }
     }


### PR DESCRIPTION
Fixes up a bug when resolving actions for an instance of a class that doesn't have actions attached to it itself, but has multiple superclasses that do have actions attached.

'[keyClass isSubclassOfClass:superClass]' would always be true, because we only ever set superClass to things that keyClass is a subclass of anyway.
