### PR TITLE
[overview] Add missing import to NIOverviewGraphView.

### DIFF
--- a/src/overview/src/NIOverviewGraphView.m
+++ b/src/overview/src/NIOverviewGraphView.m
@@ -18,6 +18,8 @@
 
 #import <QuartzCore/QuartzCore.h>
 
+#import "NIFoundationMethods.h"
+
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "Nimbus requires ARC support."
 #endif


### PR DESCRIPTION
Add a missing import after the 64-bit updates.
