### PR TITLE
Annotate NimbusCore for extension availability

### DIFF
--- a/src/core/src/NICommonMetrics.h
+++ b/src/core/src/NICommonMetrics.h
@@ -17,6 +17,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#import "NIPreprocessorMacros.h"
+
 #if defined __cplusplus
 extern "C" {
 #endif
@@ -144,7 +146,7 @@ NSTimeInterval NIStatusBarBoundsChangeAnimationDuration(void);
  *
  * This is generally 20 when the status bar is its normal height.
  */
-CGFloat NIStatusBarHeight(void);
+CGFloat NIStatusBarHeight(void) NI_EXTENSION_UNAVAILABLE_IOS("");
 
 /**
  * The animation duration when the device is rotating to a new orientation.

--- a/src/core/src/NIDeviceOrientation.h
+++ b/src/core/src/NIDeviceOrientation.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#import "NIPreprocessorMacros.h"
+
 #if defined __cplusplus
 extern "C" {
 #endif
@@ -62,7 +64,7 @@ BOOL NIIsSupportedOrientation(UIInterfaceOrientation orientation);
  *
  * @returns The current interface orientation.
  */
-UIInterfaceOrientation NIInterfaceOrientation(void);
+UIInterfaceOrientation NIInterfaceOrientation(void) NI_EXTENSION_UNAVAILABLE_IOS("");
 
 /**
  * Returns YES if the device is a phone and the orientation is landscape.

--- a/src/core/src/NINetworkActivity.h
+++ b/src/core/src/NINetworkActivity.h
@@ -18,6 +18,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "NIPreprocessorMacros.h"
+
 #if defined __cplusplus
 extern "C" {
 #endif
@@ -41,7 +43,7 @@ extern "C" {
  *
  * This method is threadsafe.
  */
-void NINetworkActivityTaskDidStart(void);
+void NINetworkActivityTaskDidStart(void) NI_EXTENSION_UNAVAILABLE_IOS("");
 
 /**
  * Decrement the number of active network tasks.

--- a/src/core/src/NINetworkActivity.m
+++ b/src/core/src/NINetworkActivity.m
@@ -17,6 +17,7 @@
 #import "NINetworkActivity.h"
 
 #import "NIDebuggingTools.h"
+#import "NIPreprocessorMacros.h"
 
 #if defined(DEBUG) || defined(NI_DEBUG)
 #import "NIRuntimeClassModifications.h"
@@ -44,7 +45,7 @@ static NSTimer* gScheduledDelayTimer = nil;
 // Called after a certain amount of time has passed since all network activity has stopped.
 // By delaying the turnoff of the network activity we avoid "flickering" effects when network
 // activity is starting and stopping rapidly.
-+ (void)disableNetworkActivity {
++ (void)disableNetworkActivity NI_EXTENSION_UNAVAILABLE_IOS("") {
   pthread_mutex_lock(&gMutex);
   if (nil != gScheduledDelayTimer) {
     [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;

--- a/src/core/src/NIPreprocessorMacros.h
+++ b/src/core/src/NIPreprocessorMacros.h
@@ -105,6 +105,19 @@ NI_FIX_CATEGORY_BUG(UIViewController_MyCustomCategory);
 #define __NI_DEPRECATED_METHOD __attribute__((deprecated))
 
 /**
+ * Mark APIs as unavailable in app extensions.
+ *
+ * Use of unavailable methods, classes, or functions produces a compile error when built as part
+ * of an app extension target. If the method, class or function using the unavailable API has also
+ * been marked as unavailable in app extensions, the error will be suppressed.
+ */
+#ifdef NS_EXTENSION_UNAVAILABLE_IOS
+#define NI_EXTENSION_UNAVAILABLE_IOS(msg) NS_EXTENSION_UNAVAILABLE_IOS(msg)
+#else
+#define NI_EXTENSION_UNAVAILABLE_IOS(msg)
+#endif
+
+/**
  * Force a category to be loaded when an app starts up.
  *
  * Add this macro before each category implementation, so we don't have to use


### PR DESCRIPTION
Resolves build errors when compiling NimbusCore into app extension targets. (on iOS 8 SDK and later)