### PR TITLE
NIPagingScrollView additions

### DIFF
--- a/src/pagingscrollview/src/NIPagingScrollView.h
+++ b/src/pagingscrollview/src/NIPagingScrollView.h
@@ -68,7 +68,11 @@ typedef enum {
 
 #pragma mark Configuring Presentation
 
+// Controls the border between images.
 @property (nonatomic) CGFloat pageMargin;
+// Used to make the view smaller than full screen, thus showing neighboring images
+// in the view.
+@property (nonatomic) CGFloat pageInset;
 @property (nonatomic) NIPagingScrollViewType type; // Default: NIPagingScrollViewHorizontal
 
 #pragma mark Visible Pages

--- a/src/photos/src/NIPhotoAlbumScrollView.m
+++ b/src/photos/src/NIPhotoAlbumScrollView.m
@@ -80,7 +80,8 @@
                                  originalPhotoDimensions: &originalPhotoDimensions];
 
   page.photoDimensions = originalPhotoDimensions;
-  page.loading = isLoading;
+  // Only mark the view as loading if the center image is loading.
+  page.loading = (page.pageIndex == self.centerPageIndex) && isLoading;
 
   if (nil == image) {
     page.zoomingIsEnabled = NO;


### PR DESCRIPTION
NIPagingScrollView.pageInset if non zero will inset the page from full screen, thus making neighboring pages visible.  This is useful for showing that there is scrollable content and presents a 'film-strip' like appearance.

Note in this case we take on the page snapping responsibilities as UIScrollView is fundamentally view bounds oriented and doens't support edges of other pages showing.