### PR TITLE
NIPagingScrollView additions - much simpler inset implementation

### DIFF
--- a/src/pagingscrollview/src/NIPagingScrollView.h
+++ b/src/pagingscrollview/src/NIPagingScrollView.h
@@ -70,7 +70,7 @@ typedef enum {
 
 // Controls the border between images.
 @property (nonatomic) CGFloat pageMargin;
-// Used to make the view smaller than full screen, thus showing neighboring images
+// Used to make the view smaller than full screen, thus showing neighboring images, horizontally
 // in the view.
 @property (nonatomic) CGFloat pageInset;
 @property (nonatomic) NIPagingScrollViewType type; // Default: NIPagingScrollViewHorizontal

--- a/src/pagingscrollview/src/NIPagingScrollView.h
+++ b/src/pagingscrollview/src/NIPagingScrollView.h
@@ -68,10 +68,11 @@ typedef enum {
 
 #pragma mark Configuring Presentation
 
-// Controls the border between images.
+// Controls the border between pages.
 @property (nonatomic) CGFloat pageMargin;
-// Used to make the view smaller than full screen, thus showing neighboring images, horizontally
-// in the view.
+// Used to make the view smaller than the frame of the paging scroll view, thus showing
+// neighboring pages, either horizontally or vertically depending on the configuration
+// of the view.
 @property (nonatomic) CGFloat pageInset;
 @property (nonatomic) NIPagingScrollViewType type; // Default: NIPagingScrollViewHorizontal
 

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -210,7 +210,7 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
 - (BOOL)isDisplayingPageForIndex:(NSInteger)pageIndex {
   BOOL foundPage = NO;
 
-  // There will never be more than 3 (5 with insets) visible pages in this array, so this lookup is
+  // There will never be more than a handful (3 without insets) of visible pages in this array, so this lookup is
   // effectively O(C) constant time.
   for (UIView <NIPagingScrollViewPage>* page in _visiblePages) {
     if (page.pageIndex == pageIndex) {

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -732,6 +732,7 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
 
 - (void)setPageInset:(CGFloat)pageInset {
   _pageInset = pageInset;
+  _scrollView.frame = [self frameForPagingScrollView];
 
   // Retain the current position.
   CGPoint offset = [self frameForPageAtIndex:_centerPageIndex].origin;

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -236,14 +236,12 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
   if (NIPagingScrollViewHorizontal == self.type) {
     // Whatever image is currently displayed in the center of the screen is the currently
     // visible image.
-    return NIBoundi((NSInteger)(NICGFloatFloor((offset + boundsSize.width / 2) /
-                                               boundsSize.width)
+    return NIBoundi((NSInteger)(NICGFloatFloor((offset + boundsSize.width / 2) / boundsSize.width)
                                 + 0.5f),
                     0, self.numberOfPages - 1);
 
   } else if (NIPagingScrollViewVertical == self.type) {
-    return NIBoundi((NSInteger)(NICGFloatFloor((offset + boundsSize.height / 2) /
-                                               boundsSize.height)
+    return NIBoundi((NSInteger)(NICGFloatFloor((offset + boundsSize.height / 2) / boundsSize.height)
                                 + 0.5f),
                     0, self.numberOfPages - 1);
   }

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -198,7 +198,7 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
 - (BOOL)isDisplayingPageForIndex:(NSInteger)pageIndex {
   BOOL foundPage = NO;
 
-  // There will never be more than 3 visible pages in this array, so this lookup is
+  // There will never be more than 3 (5 with insets) visible pages in this array, so this lookup is
   // effectively O(C) constant time.
   for (UIView <NIPagingScrollViewPage>* page in _visiblePages) {
     if (page.pageIndex == pageIndex) {
@@ -254,10 +254,11 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
     return NSMakeRange(0, 0);
   }
 
+  NSInteger visibleRange = _pageInset == 0 ? 1 : 2;
   NSInteger currentVisiblePageIndex = [self currentVisiblePageIndex];
 
-  NSInteger firstVisiblePageIndex = NIBoundi(currentVisiblePageIndex - 1, 0, self.numberOfPages - 1);
-  NSInteger lastVisiblePageIndex  = NIBoundi(currentVisiblePageIndex + 1, 0, self.numberOfPages - 1);
+  NSInteger firstVisiblePageIndex = NIBoundi(currentVisiblePageIndex - visibleRange, 0, self.numberOfPages - 1);
+  NSInteger lastVisiblePageIndex  = NIBoundi(currentVisiblePageIndex + visibleRange, 0, self.numberOfPages - 1);
 
   return NSMakeRange(firstVisiblePageIndex, lastVisiblePageIndex - firstVisiblePageIndex + 1);
 }

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -421,12 +421,6 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
   [self layoutVisiblePages];
 }
 
-- (void)layoutSubviews {
-  [super layoutSubviews];
-  _scrollView.contentSize = [self contentSizeForPagingScrollView];
-  [self layoutVisiblePages];
-}
-
 #pragma mark - UIScrollViewDelegate
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
@@ -735,6 +729,9 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
   // Retain the current position.
   CGPoint offset = [self frameForPageAtIndex:_centerPageIndex].origin;
   _scrollView.contentOffset = [self contentOffsetFromPageOffset:offset];
+
+  _scrollView.contentSize = [self contentSizeForPagingScrollView];
+  [self layoutVisiblePages];
 
   [self setNeedsLayout];
 }

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -420,6 +420,13 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
   [self layoutVisiblePages];
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+  if ([self pointInside:point withEvent:event]) {
+    return _scrollView;
+  }
+  return nil;
+}
+
 #pragma mark - UIScrollViewDelegate
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -217,12 +217,14 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
   if (NIPagingScrollViewHorizontal == self.type) {
     // Whatever image is currently displayed in the center of the screen is the currently
     // visible image.
-    return NIBoundi((NSInteger)(NICGFloatFloor((contentOffset.x + boundsSize.width / 2) / boundsSize.width)
+    return NIBoundi((NSInteger)(NICGFloatFloor((contentOffset.x + boundsSize.width / 2) /
+                                               boundsSize.width)
                               + 0.5f),
                   0, self.numberOfPages - 1);
 
   } else if (NIPagingScrollViewVertical == self.type) {
-    return NIBoundi((NSInteger)(NICGFloatFloor((contentOffset.y + boundsSize.height / 2) / boundsSize.height)
+    return NIBoundi((NSInteger)(NICGFloatFloor((contentOffset.y + boundsSize.height / 2) /
+                                               boundsSize.height)
                               + 0.5f),
                   0, self.numberOfPages - 1);
   }

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -254,7 +254,7 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
     return NSMakeRange(0, 0);
   }
 
-  NSInteger visibleRange = _pageInset == 0 ? 1 : 2;
+  NSInteger visibleRange = (_pageInset == 0) ? 1 : 2;
   NSInteger currentVisiblePageIndex = [self currentVisiblePageIndex];
 
   NSInteger firstVisiblePageIndex = NIBoundi(currentVisiblePageIndex - visibleRange, 0, self.numberOfPages - 1);
@@ -422,6 +422,7 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
 }
 
 - (void)layoutSubviews {
+  [super layoutSubviews];
   _scrollView.contentSize = [self contentSizeForPagingScrollView];
   [self layoutVisiblePages];
 }

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -217,14 +217,12 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
   if (NIPagingScrollViewHorizontal == self.type) {
     // Whatever image is currently displayed in the center of the screen is the currently
     // visible image.
-    return NIBoundi((NSInteger)(NICGFloatFloor((contentOffset.x + boundsSize.width / 2) /
-                                               boundsSize.width)
+    return NIBoundi((NSInteger)(NICGFloatFloor((contentOffset.x + boundsSize.width / 2) / boundsSize.width)
                               + 0.5f),
                   0, self.numberOfPages - 1);
 
   } else if (NIPagingScrollViewVertical == self.type) {
-    return NIBoundi((NSInteger)(NICGFloatFloor((contentOffset.y + boundsSize.height / 2) /
-                                               boundsSize.height)
+    return NIBoundi((NSInteger)(NICGFloatFloor((contentOffset.y + boundsSize.height / 2) / boundsSize.height)
                               + 0.5f),
                   0, self.numberOfPages - 1);
   }

--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -421,6 +421,8 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+  // We must forward hits for the scrollView or else the smaller frame when
+  // it is inset will prevent touches outside the scrollView bounds.
   if ([self pointInside:point withEvent:event]) {
     return _scrollView;
   }


### PR DESCRIPTION
NIPagingScrollView.pageInset if non zero will inset the page from full screen, thus making neighboring pages visible.  This is useful for showing that there is scrollable content and presents a 'film-strip' like appearance.