### PR TITLE
[networkimage] Discard canceled operations.

### DIFF
--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -343,7 +343,7 @@
                                                       scaleOptions:self.scaleOptions];
 
         // Only keep this result if it's for the most recent request.
-        if ([blockCacheKey isEqualToString:((AFHTTPRequestOperation *)self.operation.userInfo[@"cacheKey"]]) {
+        if ([blockCacheKey isEqualToString:(AFHTTPRequestOperation *)self.operation.userInfo[@"cacheKey"]]) {
           [self _didFinishLoadingWithImage:responseObject
                            cacheIdentifier:pathToNetworkImage
                                displaySize:displaySize

--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -343,7 +343,7 @@
                                                       scaleOptions:self.scaleOptions];
 
         // Only keep this result if it's for the most recent request.
-        if ([blockCacheKey isEqualToString:operation.userInfo[@"cacheKey"]]) {
+        if ([blockCacheKey isEqualToString:((AFHTTPRequestOperation *)self.operation.userInfo[@"cacheKey"]]) {
           [self _didFinishLoadingWithImage:responseObject
                            cacheIdentifier:pathToNetworkImage
                                displaySize:displaySize


### PR DESCRIPTION
The original fix will not discard canceled operation because the variable
'operation' and 'pathToNetworkImage' are still pointing to the canceled
one and thus the comparison will always return true. Fix by using
self.operation which will get updated whenever there is request.

See #442.
