### PR TITLE
Add prioritizeExplicitLinks property.

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -79,9 +79,10 @@ extern NSString* const NIAttributedLabelLinkAttributeName; // Value is an NSText
 // Please use attributedText instead. MAINTENANCE: Remove by Feb 28, 2014.
 @property (nonatomic, copy) NSAttributedString* attributedString __NI_DEPRECATED_METHOD;
 
-@property (nonatomic) BOOL                autoDetectLinks;    // Default: NO
-@property (nonatomic) NSTextCheckingType  dataDetectorTypes;  // Default: NSTextCheckingTypeLink
-@property (nonatomic) BOOL                deferLinkDetection; // Default: NO
+@property (nonatomic) BOOL                autoDetectLinks;         // Default: NO
+@property (nonatomic) NSTextCheckingType  dataDetectorTypes;       // Default: NSTextCheckingTypeLink
+@property (nonatomic) BOOL                deferLinkDetection;      // Default: NO
+@property (nonatomic) BOOL                prioritizeExplicitLinks; // Default: NO
 
 - (void)addLink:(NSURL *)urlLink range:(NSRange)range;
 - (void)removeAllExplicitLinks; // Removes all links that were added by addLink:range:. Does not remove autodetected links.

--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -698,7 +698,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
     }
   }
 
-  if (nil == foundResult) {
+  if (nil == foundResult || _prioritizeExplicitLinks) {
     for (NSTextCheckingResult* result in self.explicitLinkLocations) {
       if (NSLocationInRange(i, result.range)) {
         foundResult = result;


### PR DESCRIPTION
When set, this will cause explicitly added links to take priority over auto-detected links.