### PR TITLE
Fix trying to set page index to -1

### DIFF
--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -491,10 +491,12 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
-  [self didAnimateToPage:_animatingToPageIndex];
+  if (_animatingToPageIndex >= 0) {
+    [self didAnimateToPage:_animatingToPageIndex];
 
-  if ([self.delegate respondsToSelector:_cmd]) {
-    [self.delegate scrollViewDidEndScrollingAnimation:scrollView];
+    if ([self.delegate respondsToSelector:_cmd]) {
+      [self.delegate scrollViewDidEndScrollingAnimation:scrollView];
+    }
   }
 }
 


### PR DESCRIPTION
Fix an issue where setContentOffset:animated: with animated=NO can actually call scrollViewDidEndScrollingAnimation:, which results in trying to set the page to -1. This was causing some weird behavior