### PR TITLE
Add missing import for categories

### DIFF
--- a/src/core/src/NIOperations+Subclassing.h
+++ b/src/core/src/NIOperations+Subclassing.h
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#import "NIOperations.h"
 
 @interface NIOperation()
 @property (strong) NSError* lastError;

--- a/src/models/src/NIMutableTableViewModel+Private.h
+++ b/src/models/src/NIMutableTableViewModel+Private.h
@@ -15,6 +15,7 @@
 //
 
 #import "NIMutableTableViewModel.h"
+#import "NITableViewModel+Private.h"
 
 @interface NIMutableTableViewModel (Private)
 


### PR DESCRIPTION
This fixes a compiler error when using Nimbus code with module maps. 

Somehow, when building the code otherwise, clang will import the needed headers first, thus masking the issue