### PR TITLE
Fix crash in NICollectionViewModel/TableViewModel

### DIFF
--- a/src/collections/src/NICollectionViewModel+Private.h
+++ b/src/collections/src/NICollectionViewModel+Private.h
@@ -25,6 +25,7 @@
 - (void)_resetCompiledData;
 - (void)_compileDataWithListArray:(NSArray *)listArray;
 - (void)_compileDataWithSectionedArray:(NSArray *)sectionedArray;
+- (void)_setSectionsWithArray:(NSArray *)sectionsArray;
 
 @end
 

--- a/src/collections/src/NICollectionViewModel.m
+++ b/src/collections/src/NICollectionViewModel.m
@@ -59,7 +59,7 @@
 
 
 - (void)_resetCompiledData {
-  self.sections = nil;
+  [self _setSectionsWithArray:nil];
   self.sectionIndexTitles = nil;
   self.sectionPrefixToSectionIndex = nil;
 }
@@ -70,7 +70,7 @@
   if (nil != listArray) {
     NICollectionViewModelSection* section = [NICollectionViewModelSection section];
     section.rows = listArray;
-    self.sections = [NSArray arrayWithObject:section];
+    [self _setSectionsWithArray:@[ section ]];
   }
 }
 
@@ -132,7 +132,11 @@
   currentSectionRows = nil;
 
   // Update the compiled information for this data source.
-  self.sections = sections;
+  [self _setSectionsWithArray:sections];
+}
+
+- (void)_setSectionsWithArray:(NSArray *)sectionsArray {
+  self.sections = sectionsArray;
 }
 
 #pragma mark - UICollectionViewDataSource

--- a/src/collections/src/NIMutableCollectionViewModel.m
+++ b/src/collections/src/NIMutableCollectionViewModel.m
@@ -121,6 +121,14 @@
   return section;
 }
 
+- (void)_setSectionsWithArray:(NSArray *)sectionsArray {
+  if ([sectionsArray isKindOfClass:[NSMutableArray class]]) {
+    self.sections = (NSMutableArray *)sectionsArray;
+  } else {
+    self.sections = [sectionsArray mutableCopy];
+  }
+}
+
 @end
 
 

--- a/src/models/src/NIMutableTableViewModel.m
+++ b/src/models/src/NIMutableTableViewModel.m
@@ -99,7 +99,7 @@
 
 - (NITableViewModelSection *)_appendSection {
   if (nil == self.sections) {
-    self.sections = [NSMutableArray array];
+    [self _setSectionsWithArray:[NSMutableArray array]];
   }
   NITableViewModelSection* section = nil;
   section = [[NITableViewModelSection alloc] init];
@@ -110,7 +110,7 @@
 
 - (NITableViewModelSection *)_insertSectionAtIndex:(NSUInteger)index {
   if (nil == self.sections) {
-    self.sections = [NSMutableArray array];
+    [self _setSectionsWithArray:[NSMutableArray array]];
   }
   NITableViewModelSection* section = nil;
   section = [[NITableViewModelSection alloc] init];
@@ -118,6 +118,14 @@
   NIDASSERT(index >= 0 && index <= self.sections.count);
   [self.sections insertObject:section atIndex:index];
   return section;
+}
+
+- (void)_setSectionsWithArray:(NSArray *)sectionsArray {
+  if ([sectionsArray isKindOfClass:[NSMutableArray class]]) {
+    self.sections = (NSMutableArray *)sectionsArray;
+  } else {
+    self.sections = [sectionsArray mutableCopy];
+  }
 }
 
 #pragma mark - UITableViewDataSource

--- a/src/models/src/NITableViewModel+Private.h
+++ b/src/models/src/NITableViewModel+Private.h
@@ -26,6 +26,7 @@
 - (void)_compileDataWithListArray:(NSArray *)listArray;
 - (void)_compileDataWithSectionedArray:(NSArray *)sectionedArray;
 - (void)_compileSectionIndex;
+- (void)_setSectionsWithArray:(NSArray *)sectionsArray;
 
 @end
 

--- a/src/models/src/NITableViewModel.m
+++ b/src/models/src/NITableViewModel.m
@@ -65,7 +65,7 @@
 
 
 - (void)_resetCompiledData {
-  self.sections = nil;
+  [self _setSectionsWithArray:nil];
   self.sectionIndexTitles = nil;
   self.sectionPrefixToSectionIndex = nil;
 }
@@ -76,7 +76,7 @@
   if (nil != listArray) {
     NITableViewModelSection* section = [NITableViewModelSection section];
     section.rows = [listArray mutableCopy];
-    self.sections = [NSMutableArray arrayWithObject:section];
+    [self _setSectionsWithArray:@[ section ]];
   }
 }
 
@@ -138,7 +138,7 @@
   currentSectionRows = nil;
 
   // Update the compiled information for this data source.
-  self.sections = sections;
+  [self _setSectionsWithArray:sections];
 }
 
 - (void)_compileSectionIndex {
@@ -220,6 +220,10 @@
 
   self.sectionIndexTitles = titles;
   self.sectionPrefixToSectionIndex = sectionPrefixToSectionIndex;
+}
+
+- (void)_setSectionsWithArray:(NSArray *)sectionsArray {
+  self.sections = sectionsArray;
 }
 
 #pragma mark - UITableViewDataSource


### PR DESCRIPTION
Fixes an issue where NITableViewModel and NICollectionViewModel use immutable section arrays, which can get into the mutable subclasses. So now we have a method where the sections array is created, al
lowing us to make sure it is mutable when needed.