### PR TITLE
fix nib cell can't call heightForRowAtIndexPath method

### DIFF
--- a/src/models/src/NICellFactory.h
+++ b/src/models/src/NICellFactory.h
@@ -165,6 +165,9 @@ _model.delegate = (id)[NICellFactory class];
 /** A nib that contains a table view cell to display this object's contents. */
 - (UINib *)cellNib;
 
+/** When call the tableView's heightForRowAtIndexPath method, we need get cell class and call NITableViewModelDelegate's heightForRowAtIndexPath */
+- (Class)cellNibClass;
+
 @end
 
 /**


### PR DESCRIPTION
When we use nib to create cell,  because you can't get cell class from cellObject, so we need the cellNibClass to know which cell class that we use.