### PR TITLE
Fix an issue that can happen if we try to load pages when no data source has been set

### DIFF
--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -297,7 +297,13 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
 }
 
 - (UIView<NIPagingScrollViewPage> *)loadPageAtIndex:(NSInteger)pageIndex {
-  UIView<NIPagingScrollViewPage>* page = [self.dataSource pagingScrollView:self pageViewForIndex:pageIndex];
+  id<NIPagingScrollViewDataSource> dataSource = self.dataSource;
+  if (dataSource == nil) {
+    // If there's no data source, just return a nil page.
+    return nil;
+  }
+
+  UIView<NIPagingScrollViewPage> *page = [dataSource pagingScrollView:self pageViewForIndex:pageIndex];
 
   NIDASSERT([page isKindOfClass:[UIView class]]);
   NIDASSERT([page conformsToProtocol:@protocol(NIPagingScrollViewPage)]);


### PR DESCRIPTION
which can happen when we load offscreen pages, because the call is asynchronous, dataSource can be set to nil before it gets called.
This has no behavioral change, other than not asserting in the case that dataSource is nil.