### PR TITLE
Added support for Strikethrough on the attributed label.

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -87,6 +87,7 @@ extern NSString* const NIAttributedLabelLinkAttributeName; // Value is an NSText
 - (void)removeAllExplicitLinks; // Removes all links that were added by addLink:range:. Does not remove autodetected links.
 
 @property (nonatomic, strong) UIColor*      linkColor;                      // Default: self.tintColor (iOS 7) or [UIColor blueColor] (iOS 6)
+@property (nonatomic, strong) UIColor*      strikethroughColor;             // Default: foreground color.
 @property (nonatomic, strong) UIColor*      highlightedLinkBackgroundColor; // Default: [UIColor colorWithWhite:0.5 alpha:0.5
 @property (nonatomic)         BOOL          linksHaveUnderlines;            // Default: NO
 @property (nonatomic, copy)   NSDictionary* attributesForLinks;             // Default: nil


### PR DESCRIPTION
This adds support for strikethrough on the attributed label the tested use cases are the following:
Single line label with one run
Single label with different runs (some of which are not strikethrough)
Different color override for the strikethrough line.
Centered text
Multiline text
Text with color
Different fonts.