### PR TITLE
Upgrade insecure HTTP endpoints for Google Maps.

### DIFF
--- a/examples/catalog/Catalog/DataTypesAttributedLabelViewController.m
+++ b/examples/catalog/Catalog/DataTypesAttributedLabelViewController.m
@@ -97,7 +97,7 @@
 
   } else if (NSTextCheckingTypeAddress == result.resultType) {
     // Open the Maps application or Safari if the maps application isn't installed.
-    url = [NSURL URLWithString:[@"http://maps.google.com/maps?q=" stringByAppendingString:[[result.addressComponents objectForKey:NSTextCheckingStreetKey] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
+    url = [NSURL URLWithString:[@"https://maps.google.com/maps?q=" stringByAppendingString:[[result.addressComponents objectForKey:NSTextCheckingStreetKey] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
   }
 
   if (nil != url) {

--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1633,7 +1633,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
   } else if (NSTextCheckingTypeAddress == self.actionSheetLink.resultType) {
     NSString* address = [self.mutableAttributedString.string substringWithRange:self.actionSheetLink.range];
     if (buttonIndex == 0) {
-      [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[[@"http://maps.google.com/maps?q=" stringByAppendingString:address] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
+      [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[[@"https://maps.google.com/maps?q=" stringByAppendingString:address] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
 
     } else if (buttonIndex == 1) {
       [[UIPasteboard generalPasteboard] setString:address];

--- a/src/interapp/src/NIInterapp.m
+++ b/src/interapp/src/NIInterapp.m
@@ -134,7 +134,7 @@ static NSString* const sGoogleMapsScheme = @"comgooglemaps:";
     NSURL* url = [NSURL URLWithString:[@"comgooglemaps://" stringByAppendingString:urlString]];
     return [[UIApplication sharedApplication] openURL:url];
   } else {
-    NSURL* url = [NSURL URLWithString:[@"http://maps.google.com/maps" stringByAppendingString:urlString]];
+    NSURL* url = [NSURL URLWithString:[@"https://maps.google.com/maps" stringByAppendingString:urlString]];
     return [NIInterapp openPreferredBrowserWithURL:url];
   }
 }


### PR DESCRIPTION
Accessing Google Maps over HTTP is both insecure and deprecated.