### PR TITLE
Fix NIAttributedLabel bug: using autolayout with attributedText, the super's intrinsicContentSize is zero

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -367,6 +367,8 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
+  [super setAttributedText:attributedText];
+
   if (self.mutableAttributedString != attributedText) {
     self.mutableAttributedString = [attributedText mutableCopy];
 


### PR DESCRIPTION
This could cause the result intrinsicContentSize is wrong.