### PR TITLE
Revert "Fix NIAttributedLabel bug: using autolayout with attributedText, the super's intrinsicContentSize is zero"

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -367,8 +367,6 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
-  [super setAttributedText:attributedText];
-
   if (self.mutableAttributedString != attributedText) {
     self.mutableAttributedString = [attributedText mutableCopy];
 


### PR DESCRIPTION
Reverts jverkoey/nimbus#642.

The original change causes behavioral changes. We'll need to allow teams to move forward with this patch in a slower manner, likely with runtime flags.