### PR TITLE
Upgrade insecure HTTP endpoints for Google Maps

### DIFF
--- a/examples/catalog/Catalog/DataTypesAttributedLabelViewController.m
+++ b/examples/catalog/Catalog/DataTypesAttributedLabelViewController.m
@@ -97,7 +97,7 @@
 
   } else if (NSTextCheckingTypeAddress == result.resultType) {
     // Open the Maps application or Safari if the maps application isn't installed.
-    url = [NSURL URLWithString:[@"http://maps.google.com/maps?q=" stringByAppendingString:[[result.addressComponents objectForKey:NSTextCheckingStreetKey] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
+    url = [NSURL URLWithString:[@"https://maps.google.com/maps?q=" stringByAppendingString:[[result.addressComponents objectForKey:NSTextCheckingStreetKey] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
   }
 
   if (nil != url) {

--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1660,7 +1660,7 @@ _NI_UIACTIONSHEET_DEPRECATION_SUPPRESSION_PUSH()
       NSString *escapedAddress =
           NIStringByAddingPercentEscapesForURLParameterString(address);
       NSString *URLString =
-          [NSString stringWithFormat:@"http://maps.google.com/maps?q=%@", escapedAddress];
+          [NSString stringWithFormat:@"https://maps.google.com/maps?q=%@", escapedAddress];
       NSURL *URL = [NSURL URLWithString:URLString];
       [[UIApplication sharedApplication] openURL:URL];
 

--- a/src/interapp/src/NIInterapp.m
+++ b/src/interapp/src/NIInterapp.m
@@ -134,7 +134,7 @@ static NSString* const sGoogleMapsScheme = @"comgooglemaps:";
     NSURL* url = [NSURL URLWithString:[@"comgooglemaps://" stringByAppendingString:urlString]];
     return [[UIApplication sharedApplication] openURL:url];
   } else {
-    NSURL* url = [NSURL URLWithString:[@"http://maps.google.com/maps" stringByAppendingString:urlString]];
+    NSURL* url = [NSURL URLWithString:[@"https://maps.google.com/maps" stringByAppendingString:urlString]];
     return [NIInterapp openPreferredBrowserWithURL:url];
   }
 }


### PR DESCRIPTION
Accessing Google Maps over HTTP is both insecure and deprecated.