### PR TITLE
Fix NIAttributedLabel race condition relating to deferred auto link detection

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -214,7 +214,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
 
 @property (nonatomic) CTFrameRef textFrame; // CFType, manually managed lifetime, see setter.
 
-@property (nonatomic, assign) NSInteger linkDetectionGeneration;
+@property (nonatomic, assign) NSInteger linkDetectionRequestID;
 @property (nonatomic)         BOOL linksHaveBeenDetected;
 @property (nonatomic, copy)   NSArray*        detectedlinkLocations;
 @property (nonatomic, strong) NSMutableArray* explicitLinkLocations;  // Of NSTextCheckingResult.
@@ -390,7 +390,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
     // Clear the link caches.
     self.detectedlinkLocations = nil;
     self.linksHaveBeenDetected = NO;
-    self.linkDetectionGeneration++;
+    self.linkDetectionRequestID++;
     [self removeAllExplicitLinks];
 
     // Remove all images.
@@ -668,14 +668,14 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
 }
 
 - (void)_deferLinkDetection {
-  self.linkDetectionGeneration++;
-  NSInteger linkDetectionGeneration = self.linkDetectionGeneration;
+  self.linkDetectionRequestID++;
+  const NSInteger linkDetectionRequestID = self.linkDetectionRequestID;
   NSString* string = [self.mutableAttributedString.string copy];
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     NSArray* matches = [self _matchesFromAttributedString:string];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-      if (self.linkDetectionGeneration != linkDetectionGeneration) {
+      if (self.linkDetectionRequestID != linkDetectionRequestID) {
         return;
       }
       self.detectedlinkLocations = matches;


### PR DESCRIPTION
Fix two race condition issues in NIAttributedLabel relating to deferred auto link detection:
1) If the label's string is rapidly changed (such as when scrolling and reusing cells), it is possible for the link detection results for a previous string to be applied to a newer, causing out of range errors and resulting in crashes.
2) In the same circumstances as 1), even if we don't crash, the second string is prevented from having its links detected since the detection for the previous string hasn't finished and detectingLinks is still YES.