### PR TITLE
Support NSFastEnumeration on NICollectionViewModel...

### DIFF
--- a/src/collections/src/NICollectionViewModel+Private.h
+++ b/src/collections/src/NICollectionViewModel+Private.h
@@ -21,6 +21,7 @@
 @property (nonatomic, strong) NSArray* sections; // Array of NICollectionViewModelSection
 @property (nonatomic, strong) NSArray* sectionIndexTitles;
 @property (nonatomic, strong) NSDictionary* sectionPrefixToSectionIndex;
+// Required by NSFastEnumeration so that compiler-generated code can detect mutations
 @property (nonatomic) unsigned long mutationCount;
 
 - (void)_resetCompiledData;

--- a/src/collections/src/NICollectionViewModel+Private.h
+++ b/src/collections/src/NICollectionViewModel+Private.h
@@ -21,6 +21,7 @@
 @property (nonatomic, strong) NSArray* sections; // Array of NICollectionViewModelSection
 @property (nonatomic, strong) NSArray* sectionIndexTitles;
 @property (nonatomic, strong) NSDictionary* sectionPrefixToSectionIndex;
+@property (nonatomic) unsigned long mutationCount;
 
 - (void)_resetCompiledData;
 - (void)_compileDataWithListArray:(NSArray *)listArray;

--- a/src/collections/src/NICollectionViewModel.h
+++ b/src/collections/src/NICollectionViewModel.h
@@ -42,7 +42,8 @@
  *
  * @ingroup CollectionViewModels
  */
-@interface NICollectionViewModel : NSObject <NIActionsDataSource, UICollectionViewDataSource>
+@interface NICollectionViewModel : NSObject <NIActionsDataSource, UICollectionViewDataSource,
+    NSFastEnumeration>
 
 #pragma mark Creating Collection View Models
 

--- a/src/collections/src/NICollectionViewModel.m
+++ b/src/collections/src/NICollectionViewModel.m
@@ -190,7 +190,7 @@
     state->mutationsPtr = &_mutationCount;
   }
 
-  NSArray<NICollectionViewModelSection *> *sections = self.sections;
+  NSArray *sections = self.sections;
 
   // Destination index into the output buffer
   NSUInteger dstIdx = 0;
@@ -199,7 +199,7 @@
 
   NSUInteger numSections = sections.count;
   for (; sectionIdx < numSections && dstIdx < len; sectionIdx++) {
-    NSArray *rows = sections[sectionIdx].rows;
+    NSArray *rows = [sections[sectionIdx] rows];
     NSUInteger numItems = rows.count;
     for (; itemIdx < numItems && dstIdx < len; itemIdx++) {
       buffer[dstIdx++] = rows[itemIdx];

--- a/src/collections/src/NICollectionViewModel.m
+++ b/src/collections/src/NICollectionViewModel.m
@@ -192,6 +192,7 @@
 
   NSArray<NICollectionViewModelSection *> *sections = self.sections;
 
+  // Destination index into the output buffer
   NSUInteger dstIdx = 0;
   unsigned long sectionIdx = state->extra[kExtraSectionIndex];
   unsigned long itemIdx = state->extra[kExtraItemIndex];

--- a/src/collections/src/NICollectionViewModel.m
+++ b/src/collections/src/NICollectionViewModel.m
@@ -176,6 +176,46 @@
   return nil;
 }
 
+#pragma mark - NSFastEnumeration
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id  _Nonnull *)buffer count:(NSUInteger)len {
+  // Named indexes into state->extra.
+  static const unsigned int kExtraSectionIndex = 0;
+  static const unsigned int kExtraItemIndex = 1;
+
+  // Initial setup is needed when state is zero.
+  if (state->state == 0) {
+    state->state = 1;
+    state->itemsPtr = buffer;
+    state->mutationsPtr = &_mutationCount;
+  }
+
+  NSArray<NICollectionViewModelSection *> *sections = self.sections;
+
+  NSUInteger dstIdx = 0;
+  unsigned long sectionIdx = state->extra[kExtraSectionIndex];
+  unsigned long itemIdx = state->extra[kExtraItemIndex];
+
+  NSUInteger numSections = sections.count;
+  for (; sectionIdx < numSections && dstIdx < len; sectionIdx++) {
+    NSArray *rows = sections[sectionIdx].rows;
+    NSUInteger numItems = rows.count;
+    for (; itemIdx < numItems && dstIdx < len; itemIdx++) {
+      buffer[dstIdx++] = rows[itemIdx];
+    }
+    if (itemIdx >= numItems) {
+      itemIdx = 0;
+    }
+  }
+
+  // Store the index values for continuing iteration on the next call.
+  state->extra[kExtraSectionIndex] = sectionIdx;
+  state->extra[kExtraItemIndex] = itemIdx;
+
+  // Return the number of items copied.
+  return dstIdx;
+}
+
 #pragma mark - Public
 
 

--- a/src/collections/src/NIMutableCollectionViewModel.m
+++ b/src/collections/src/NIMutableCollectionViewModel.m
@@ -35,6 +35,7 @@
 
 - (NSArray *)addObject:(id)object {
   NICollectionViewModelSection* section = self.sections.count == 0 ? [self _appendSection] : self.sections.lastObject;
+  self.mutationCount++;
   [section.mutableRows addObject:object];
   return [NSArray arrayWithObject:[NSIndexPath indexPathForRow:section.mutableRows.count - 1
                                                      inSection:self.sections.count - 1]];
@@ -43,6 +44,7 @@
 - (NSArray *)addObject:(id)object toSection:(NSUInteger)sectionIndex {
   NIDASSERT(sectionIndex >= 0 && sectionIndex < self.sections.count);
   NICollectionViewModelSection *section = [self.sections objectAtIndex:sectionIndex];
+  self.mutationCount++;
   [section.mutableRows addObject:object];
   return [NSArray arrayWithObject:[NSIndexPath indexPathForRow:section.mutableRows.count - 1
                                                      inSection:sectionIndex]];
@@ -59,6 +61,7 @@
 - (NSArray *)insertObject:(id)object atRow:(NSUInteger)row inSection:(NSUInteger)sectionIndex {
   NIDASSERT(sectionIndex >= 0 && sectionIndex < self.sections.count);
   NICollectionViewModelSection *section = [self.sections objectAtIndex:sectionIndex];
+  self.mutationCount++;
   [section.mutableRows insertObject:object atIndex:row];
   return [NSArray arrayWithObject:[NSIndexPath indexPathForRow:row inSection:sectionIndex]];
 }
@@ -73,6 +76,7 @@
   if (indexPath.row >= (NSInteger)section.mutableRows.count) {
     return nil;
   }
+  self.mutationCount++;
   [section.mutableRows removeObjectAtIndex:indexPath.row];
   return [NSArray arrayWithObject:indexPath];
 }
@@ -91,6 +95,7 @@
 
 - (NSIndexSet *)removeSectionAtIndex:(NSUInteger)index {
   NIDASSERT(index >= 0 && index < self.sections.count);
+  self.mutationCount++;
   [self.sections removeObjectAtIndex:index];
   return [NSIndexSet indexSetWithIndex:index];
 }
@@ -105,6 +110,7 @@
   NICollectionViewModelSection* section = nil;
   section = [[NICollectionViewModelSection alloc] init];
   section.rows = [NSMutableArray array];
+  self.mutationCount++;
   [self.sections addObject:section];
   return section;
 }
@@ -117,11 +123,13 @@
   section = [[NICollectionViewModelSection alloc] init];
   section.rows = [NSMutableArray array];
   NIDASSERT(index >= 0 && index <= self.sections.count);
+  self.mutationCount++;
   [self.sections insertObject:section atIndex:index];
   return section;
 }
 
 - (void)_setSectionsWithArray:(NSArray *)sectionsArray {
+  self.mutationCount++;
   if ([sectionsArray isKindOfClass:[NSMutableArray class]]) {
     self.sections = (NSMutableArray *)sectionsArray;
   } else {


### PR DESCRIPTION
…and NIMutableCollectionViewModel.

This allows iterating over the objects contained in NICollectionViewModel and subclasses, which was previously not supported. Clients may call -indexPathForObject: if necessary to obtain index paths for the enumerated items.
