### PR TITLE
Make -[NIAttributedLabel linkAtPoint:] public.

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -119,6 +119,8 @@ extern NSString* const NIAttributedLabelLinkAttributeName; // Value is an NSText
 
 - (void)invalidateAccessibleElements;
 
+- (NSTextCheckingResult *)linkAtPoint:(CGPoint)point;
+
 @property (nonatomic, weak) IBOutlet id<NIAttributedLabelDelegate> delegate;
 @end
 


### PR DESCRIPTION
i have a scenario where a gesture recognizer on label's superview is conflicting with touchBegan/End/etc handlers of `NIAttributedLabel`.. I need touch outside the link to trigger my gestureRecognizer, while touch inside the link to trigger the `NIAttributedLabel`'s delegate callback..

however, gestureRecognizer always takes precedence.

therefore, i wish to do:

```
// roughly...
-(BOOL)gestureRecognizerShouldBegin:(id)sender {
   NSTextCheckingResult *result = [_label linkAtPoint:..];
   if (result.resultType == .. && result.URL) { 
     return NO;
   }
   return YES;
}
```

..and in order to do that, i need to have `linkAtPoint:` exposed as public