### PR TITLE
fix multiline label sizing when numberOfLines == 1

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -35,6 +35,19 @@ extern "C" {
  */
 CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedString, CGSize size, NSInteger numberOfLines);
 
+/**
+ * By default, the size calculation (sizeThatFits:) for a multiline string (w/ newline chars) with
+ * numberOfLines == 1 returns a height that would fit all lines instead of just the first line.
+ * The intent was to return a width that can fit the entire string in one line, but the
+ * implementation didn't account for presence of newline chars in the string.
+ *
+ * When enabled, it fixes such size calculation to return the size for just the first line as
+ * expected. This matches the UILabel size calculation behavior as well.
+ *
+ * This is disabled by default due to existing clients that may depend on the legacy behavior.
+ */
+void NIAttributedLabelEnableSingleLineSizeCalculationFix(void);
+
 #if defined __cplusplus
 };
 #endif

--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -87,10 +87,10 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
   // This logic adapted from @mattt's TTTAttributedLabel
   // https://github.com/mattt/TTTAttributedLabel
 
-  if (numberOfLines == 1) {
-    constraintSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
-
-  } else if (numberOfLines > 0 && nil != framesetter) {
+  if (numberOfLines > 0 && nil != framesetter) {
+    if (numberOfLines == 1) {
+      constraintSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
+    } 
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathAddRect(path, NULL, CGRectMake(0, 0, constraintSize.width, constraintSize.height));
     CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), path, NULL);

--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -66,7 +66,7 @@ static const void *kFontAttributeKey = @"NSFont";
 static const void *kStrikethroughAttributeKey = @"NSStrikethrough";
 static const void *kStrikethroughColorAttributeKey = @"NSStrikethroughColorAttributeName";
 
-static BOOL sEnableSingleLineSizeCalculationFix = false;
+static BOOL sEnableSingleLineSizeCalculationFix = NO;
 
 // For supporting images.
 CGFloat NIImageDelegateGetAscentCallback(void* refCon);
@@ -74,7 +74,7 @@ CGFloat NIImageDelegateGetDescentCallback(void* refCon);
 CGFloat NIImageDelegateGetWidthCallback(void* refCon);
 
 void NIAttributedLabelEnableSingleLineSizeCalculationFix(void) {
-  sEnableSingleLineSizeCalculationFix = true;
+  sEnableSingleLineSizeCalculationFix = YES;
 }
 
 CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedString, CGSize constraintSize, NSInteger numberOfLines) {

--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -66,10 +66,16 @@ static const void *kFontAttributeKey = @"NSFont";
 static const void *kStrikethroughAttributeKey = @"NSStrikethrough";
 static const void *kStrikethroughColorAttributeKey = @"NSStrikethroughColorAttributeName";
 
+static BOOL sEnableSingleLineSizeCalculationFix = false;
+
 // For supporting images.
 CGFloat NIImageDelegateGetAscentCallback(void* refCon);
 CGFloat NIImageDelegateGetDescentCallback(void* refCon);
 CGFloat NIImageDelegateGetWidthCallback(void* refCon);
+
+void NIAttributedLabelEnableSingleLineSizeCalculationFix(void) {
+  sEnableSingleLineSizeCalculationFix = true;
+}
 
 CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedString, CGSize constraintSize, NSInteger numberOfLines) {
   if (nil == attributedString) {
@@ -87,10 +93,12 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
   // This logic adapted from @mattt's TTTAttributedLabel
   // https://github.com/mattt/TTTAttributedLabel
 
-  if (numberOfLines > 0 && nil != framesetter) {
+  if (!sEnableSingleLineSizeCalculationFix && numberOfLines == 1) {
+    constraintSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
+  } else if (numberOfLines > 0 && nil != framesetter) {
     if (numberOfLines == 1) {
       constraintSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
-    } 
+    }
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathAddRect(path, NULL, CGRectMake(0, 0, constraintSize.width, constraintSize.height));
     CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), path, NULL);


### PR DESCRIPTION
When `numberOfLines == 1` and `text` has newline chars (e.g. `@"multiline_start\n\n\n\nmultiline_end"`), then the code was returning a `size` that can fit all lines -- ignoring the `numberOfLines == 1 `.

This is:
1. different from `UILabel` behavior; it respects `numberOfLines == 1` for multiline string.
2. renders wrong (tall label w/ top-aligned text) whereas `UILabel` renders correctly.

repro test code:
```
NSAttributedString *text = [[NSAttributedString alloc] initWithString:@"@"multi_start\n\n\n\n\n\n\n\nmulti_end""];
NIAttributedLabel *label = [[NIAttributedLabel alloc] init];
label.numberOfLines = 1; // not actually necessary since it's default.
label.attributedText = text;
CGSize size = [label sizeThatFits:CGSizeMake(300, 20)];
// actual height returned is 135; expected height was ~10-20 for single-line.
```

The original author's intent was that, if `numberOfLines == 1`, then `-[label sizeThatFits:]` should ignore the given constraint and extend the current width (common use-case) to fit all strings in a single-line, so he made the `constraintSize.width` unbounded 
(original author's comment here: https://github.com/TTTAttributedLabel/TTTAttributedLabel/pull/28).

His intent actually matches `UILabel` behavior because `UILabel` does the same thing.

However, he missed the case where the string itself might contain newline characters; and since he has set `constraintSize.height` unbounded as well, the `size` being returned was accounting for all lines in the `text` despite `numberOfLines == 1`.

The proposed fix keeps the original intent of the code (constraintSize becomes unbounded when `numberOfLines == 1`), but fixes it so that the size that's returned is bounded to the first line of multiline string.