### PR TITLE
Ignore request cancelation error in NINetworkImage block-based flow

### DIFF
--- a/src/networkimage/src/NINetworkImageView.m
+++ b/src/networkimage/src/NINetworkImageView.m
@@ -354,6 +354,11 @@
         }
 
       } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+         // We often cancel requests ourselves and AFNetworking will too if we request the same URL
+         // again before it's loaded.
+         if (error.code == NSURLErrorCancelled) {
+             return;
+         }
          [self _didFailToLoadWithError:error];
       }];
 


### PR DESCRIPTION
This was already done for NIOperations, and with good reason.

The way to test this change is by using large images in a table view with lots of rows, and scroll up and down to force two equivalent requests to run in the same cell (for the same image URL).

Expected: Things load.
Actual: Occasionally a cell will remain blank, and the reason is AFNetworking cancels the duplicate request, but instead of ignoring that cancelation (like we do for NIOperations), we wipe our operation var. Which eventually leads to ignoring the successful completion of the surviving image request, when we should in fact proceed and load the image as normal.