### PR TITLE
Use the correct type when getting NSUnderlineStyle from CFNumber

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1644,7 +1644,7 @@ _NI_UIACTIONSHEET_DEPRECATION_SUPPRESSION_POP()
                                   ctx:(CGContextRef)ctx {
   CFNumberRef styleRef = CFDictionaryGetValue(attributes, kStrikethroughAttributeKey);
   NSUnderlineStyle style = 0;
-  CFNumberGetValue(styleRef, kCFNumberSInt64Type, &style);
+  CFNumberGetValue(styleRef, kCFNumberNSIntegerType, &style);
   if (style == NSUnderlineStyleNone) {
     return;
   }


### PR DESCRIPTION
NSUnderlineStyle is defined as an NSInteger. The code was using kCFNumberSInt64Type in CFNumberGetValue which worked fine on 64 bit devices, but on 32 bit devices would be trying to put 64 bits into a 32 bit integer. On the iPhone 5 simulator this causes a crash. On a device, I believe this would silently overwrite the next 32 bits in memory.