### PR TITLE
Only change text color when highlighted if highlighted text color exists.

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1410,7 +1410,7 @@ _NI_UIACTIONSHEET_DEPRECATION_SUPPRESSION_POP()
     }
   }
 
-  if (self.isHighlighted) {
+  if (self.isHighlighted && self.highlightedTextColor) {
     [attributedString setTextColor:self.highlightedTextColor];
   }
 


### PR DESCRIPTION
This behavior (assuming that this change is all that's required) would more closely match the behavior described in Apple's [UILabel documentation](https://developer.apple.com/documentation/uikit/uilabel/1620540-highlightedtextcolor):

> In order for the highlight to be drawn, the highlightedTextColor property must contain a non-nil value.