### PR TITLE
[paging-scroll-view] Fix an exception thrown when NIPagingScrollView rotates with a zero frame 💥

### DIFF
--- a/src/pagingscrollview/src/NIPagingScrollView.m
+++ b/src/pagingscrollview/src/NIPagingScrollView.m
@@ -645,6 +645,12 @@ const CGFloat NIPagingScrollViewDefaultPageInset = 0;
   CGFloat offset = [self scrolledPageOffset];
   CGFloat pageScrollableDimension = [self pageScrollableDimension];
 
+  if (pageScrollableDimension == 0) {
+    _firstVisiblePageIndexBeforeRotation = 0;
+    _percentScrolledIntoFirstVisiblePage = 0.f;
+    return;
+  }
+
   if (offset >= 0) {
     _firstVisiblePageIndexBeforeRotation = (NSInteger)NICGFloatFloor(offset / pageScrollableDimension);
     _percentScrolledIntoFirstVisiblePage = ((offset

--- a/src/pagingscrollview/unittests/NIPagingScrollViewTests.m
+++ b/src/pagingscrollview/unittests/NIPagingScrollViewTests.m
@@ -23,11 +23,17 @@
 @interface NIPagingScrollViewTests : XCTestCase
 @end
 
-
 @implementation NIPagingScrollViewTests
 
+/** Test that rotating with a zero frame does not throw exceptions. */
+- (void)testRotationWithZeroFrame {
+  NIPagingScrollView *pagingScrollView = [[NIPagingScrollView alloc] initWithFrame:CGRectZero];
+  UIInterfaceOrientation targetInterfaceOrientation = UIInterfaceOrientationPortrait;
+  XCTAssertNoThrow([pagingScrollView willRotateToInterfaceOrientation:targetInterfaceOrientation
+                                                             duration:0.25]);
+  XCTAssertNoThrow([pagingScrollView willAnimateRotationToInterfaceOrientation:targetInterfaceOrientation
+                                                                      duration:0.25]);
 
-- (void)testNothing {
 }
 
 @end


### PR DESCRIPTION
Also add tests to catch exceptions thrown when rotating NIPagingScrollView with a zero frame.