### PR TITLE
Replace use of deprecated -stringByReplacingPercentEscapesUsingEncoding:.

### DIFF
--- a/src/core/src/NIFoundationMethods.h
+++ b/src/core/src/NIFoundationMethods.h
@@ -251,7 +251,12 @@ NSComparisonResult NICompareVersionStrings(NSString* string1, NSString* string2)
  * in the query. Otherwise each object in the array with be an NSString corresponding to a value
  * in the query for that parameter.
  */
-NSDictionary* NIQueryDictionaryFromStringUsingEncoding(NSString* string, NSStringEncoding encoding);
+NSDictionary* NIQueryDictionaryFromString(NSString* string);
+
+/**
+ * Deprecated method. Use NIQueryDictionaryFromString instead.
+ */
+NSDictionary* NIQueryDictionaryFromStringUsingEncoding(NSString* string, NSStringEncoding encoding) __NI_DEPRECATED_METHOD; // Use NIQueryDictionaryFromString instead.
 
 /**
  * Returns a string that has been escaped for use as a URL parameter.

--- a/src/core/src/NIFoundationMethods.m
+++ b/src/core/src/NIFoundationMethods.m
@@ -212,6 +212,39 @@ NSComparisonResult NICompareVersionStrings(NSString* string1, NSString* string2)
   return [oneAlpha compare:twoAlpha];
 }
 
+
+NSDictionary* NIQueryDictionaryFromString(NSString* string) {
+  NSCharacterSet* delimiterSet = [NSCharacterSet characterSetWithCharactersInString:@"&;"];
+  NSMutableDictionary* pairs = [NSMutableDictionary dictionary];
+  NSScanner* scanner = [[NSScanner alloc] initWithString:string];
+
+  while (![scanner isAtEnd]) {
+    NSString* pairString = nil;
+    [scanner scanUpToCharactersFromSet:delimiterSet intoString:&pairString];
+    [scanner scanCharactersFromSet:delimiterSet intoString:NULL];
+
+    NSArray* kvPair = [pairString componentsSeparatedByString:@"="];
+    if (kvPair.count == 1 || kvPair.count == 2) {
+      NSString* key = [kvPair[0] stringByRemovingPercentEncoding];
+
+      NSMutableArray* values = pairs[key];
+      if (nil == values) {
+        values = [NSMutableArray array];
+        pairs[key] = values;
+      }
+
+      if (kvPair.count == 1) {
+        [values addObject:[NSNull null]];
+
+      } else if (kvPair.count == 2) {
+        NSString* value = [kvPair[1] stringByRemovingPercentEncoding];
+        [values addObject:value];
+      }
+    }
+  }
+  return [pairs copy];
+}
+
 NSDictionary* NIQueryDictionaryFromStringUsingEncoding(NSString* string, NSStringEncoding encoding) {
   NSCharacterSet* delimiterSet = [NSCharacterSet characterSetWithCharactersInString:@"&;"];
   NSMutableDictionary* pairs = [NSMutableDictionary dictionary];

--- a/src/core/unittests/NICoreAdditionTests.m
+++ b/src/core/unittests/NICoreAdditionTests.m
@@ -32,6 +32,79 @@
 
 #pragma mark - NSString Additions
 
+- (void)testNSString_queryContents {
+  NSDictionary* query;
+
+  query = NIQueryDictionaryFromString(@"");
+  XCTAssertTrue([query count] == 0, @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q");
+  XCTAssertTrue([query[@"q"] isEqual:@[[NSNull null]]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=");
+  XCTAssertTrue([query[@"q"] isEqual:@[@""]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=three20");
+  XCTAssertTrue([query[@"q"] isEqual:@[@"three20"]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=three20%20github");
+  XCTAssertTrue([query[@"q"] isEqual:@[@"three20 github"]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=three20&hl=en");
+  XCTAssertTrue([query[@"q"] isEqual:@[@"three20"]],
+                @"Query: %@", query);
+  XCTAssertTrue([query[@"hl"] isEqual:@[@"en"]],
+                 @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=three20&hl=");
+  XCTAssertTrue([query[@"q"] isEqual:@[@"three20"]],
+                @"Query: %@", query);
+  XCTAssertTrue([query[@"hl"] isEqual:@[@""]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=&&hl=");
+  XCTAssertTrue([query[@"q"] isEqual:@[@""]],
+                @"Query: %@", query);
+  XCTAssertTrue([query[@"hl"] isEqual:@[@""]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=three20=repo&hl=en");
+  XCTAssertNil(query[@"q"], @"Query: %@", query);
+  XCTAssertTrue([query[@"hl"] isEqual:@[@"en"]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"&&");
+  XCTAssertTrue([query count] == 0, @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=foo&q=three20");
+  NSArray* qArr = @[@"foo", @"three20"];
+  XCTAssertTrue([query[@"q"] isEqual:qArr], @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=foo&q=three20&hl=en");
+  qArr = @[@"foo", @"three20"];
+  XCTAssertTrue([query[@"q"] isEqual:qArr], @"Query: %@", query);
+  XCTAssertTrue([query[@"hl"] isEqual:@[@"en"]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q=foo&q=three20&hl=en&g");
+  qArr = @[@"foo", @"three20"];
+  XCTAssertTrue([query[@"q"] isEqual:qArr], @"Query: %@", query);
+  XCTAssertTrue([query[@"hl"] isEqual:@[@"en"]],
+                @"Query: %@", query);
+  XCTAssertTrue([query[@"g"] isEqual:@[[NSNull null]]],
+                @"Query: %@", query);
+
+  query = NIQueryDictionaryFromString(@"q&q=three20&hl=en&g");
+  qArr = @[[NSNull null], @"three20"];
+  XCTAssertTrue([query[@"q"] isEqual:qArr], @"Query: %@", query);
+  XCTAssertTrue([query[@"hl"] isEqual:@[@"en"]],
+                @"Query: %@", query);
+}
+
 - (void)testNSString_queryContentsUsingEncoding {
 	NSDictionary* query;
 


### PR DESCRIPTION
This commit clears this warning:

src/core/src/NIFoundationMethods.m:227:34: warning: 'stringByReplacingPercentEscapesUsingEncoding:' is deprecated: first deprecated in iOS 9.0 - Use -stringByRemovingPercentEncoding instead, which always uses the recommended UTF-8 encoding. [-Wdeprecated-declarations]
      NSString* key = [kvPair[0] stringByReplacingPercentEscapesUsingEncoding:encoding];
                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator11.1.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURL.h:593:1: note: 'stringByReplacingPercentEscapesUsingEncoding:' has been explicitly marked deprecated here
- (nullable NSString *)stringByReplacingPercentEscapesUsingEncoding:(NSStringEncoding)enc API_DEPRECATED("Use -stringByRemovingPercentEncoding instead, which always uses the recommended UTF-8 encoding.", macos(10.0,10.11), ios(2.0,9.0), watchos(2.0,2.0), tvos(9.0,9.0));
^
src/core/src/NIFoundationMethods.m:239:38: warning: 'stringByReplacingPercentEscapesUsingEncoding:' is deprecated: first deprecated in iOS 9.0 - Use -stringByRemovingPercentEncoding instead, which always uses the recommended UTF-8 encoding. [-Wdeprecated-declarations]
        NSString* value = [kvPair[1] stringByReplacingPercentEscapesUsingEncoding:encoding];
                                     ^
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator11.1.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURL.h:593:1: note: 'stringByReplacingPercentEscapesUsingEncoding:' has been explicitly marked deprecated here
- (nullable NSString *)stringByReplacingPercentEscapesUsingEncoding:(NSStringEncoding)enc API_DEPRECATED("Use -stringByRemovingPercentEncoding instead, which always uses the recommended UTF-8 encoding.", macos(10.0,10.11), ios(2.0,9.0), watchos(2.0,2.0), tvos(9.0,9.0));
^