### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - LC_CTYPE=en_US.UTF-8
   - LANG=en_US.UTF-8
   matrix:
-    - DESTINATION="OS=10.3,name=iPhone 6s" SDK=iphonesimulator10.3
+    - DESTINATION="OS=10.3.1,name=iPhone 6s" SDK=iphonesimulator10.3
     - DESTINATION="OS=9.1,name=iPhone 6s" SDK=iphonesimulator10.3
     - DESTINATION="OS=9.0,name=iPhone 6 Plus" SDK=iphonesimulator10.3
     - DESTINATION="OS=8.4,name=iPhone 6" SDK=iphonesimulator10.3


### PR DESCRIPTION
10.3 is not available. Instead use 10.3.1.

See https://travis-ci.org/jverkoey/nimbus/jobs/311646947 for the error this CL fixes.