### PR TITLE
Delete stale documentation.

### DIFF
--- a/src/collections/src/NIMutableCollectionViewModel.h
+++ b/src/collections/src/NIMutableCollectionViewModel.h
@@ -143,13 +143,3 @@
  * @returns An index set with a single index representing the index of the removed section.
  * @fn NIMutableCollectionViewModel::removeSectionAtIndex:
  */
-
-/** @name Updating the Section Index */
-
-/**
- * Updates the section index with the current section index settings.
- *
- * This method should be called after modifying the model if a section index is being used.
- *
- * @fn NIMutableCollectionViewModel::updateSectionIndex
- */


### PR DESCRIPTION
updateSectionIndex is no longer anywhere in the API, but the documentation still exists.