### PR TITLE
[photos] Fix up format strings

### DIFF
--- a/src/photos/src/NIToolbarPhotoViewController.m
+++ b/src/photos/src/NIToolbarPhotoViewController.m
@@ -427,9 +427,9 @@
 }
 
 - (void)setChromeTitle {
-  self.title = [NSString stringWithFormat:@"%zd of %zd",
-                (self.photoAlbumView.centerPageIndex + 1),
-                self.photoAlbumView.numberOfPages];
+  self.title = [NSString stringWithFormat:@"%ld of %ld",
+                (long)(self.photoAlbumView.centerPageIndex + 1),
+                (long)self.photoAlbumView.numberOfPages];
 }
 
 #pragma mark - NIPhotoAlbumScrollViewDelegate


### PR DESCRIPTION
Ensure format strings match their arguments. Cast `NSInteger` and `NSUInteger` to `long` and `unsigned long`, respectively, before printing.