### PR TITLE
[attributed-label] Add delegate method for long presses on attributed label data detector results 👇

### DIFF
--- a/src/Nimbus.xcodeproj/project.pbxproj
+++ b/src/Nimbus.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		D5BCE8BE1D753B9100B6715F /* libNimbusCollections.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66FC984A1703F9D7004E8FB8 /* libNimbusCollections.a */; };
 		D5BCE8C11D753BCE00B6715F /* libNimbusCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66A03C0913E6E85E00B514F3 /* libNimbusCore.a */; };
 		D5BCE8C41D762F1600B6715F /* libNimbusModels.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6661BBCC13F1A3BB00D14F92 /* libNimbusModels.a */; };
+		D5E5929D221246140076B697 /* NIAttributedLabel+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = D5E59299221245200076B697 /* NIAttributedLabel+Testing.h */; };
 		DB3A231913FD4B8E00614220 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66A03C0C13E6E85E00B514F3 /* Foundation.framework */; };
 		DB3A231D13FD4B8E00614220 /* libNimbusAttributedLabel.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB3A230913FD4B8E00614220 /* libNimbusAttributedLabel.a */; };
 		DB3A233613FD4BE500614220 /* NIAttributedLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = DB3A233213FD4BE500614220 /* NIAttributedLabel.h */; };
@@ -929,6 +930,7 @@
 		D5BCE8B71D7539A300B6715F /* NimbusCollectionsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbusCollectionsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5BCE8B91D753A1100B6715F /* NimbusCollectionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NimbusCollectionsTests.m; path = unittests/NimbusCollectionsTests.m; sourceTree = "<group>"; };
 		D5BCE8C51D76359200B6715F /* NimbusCollectionsTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "NimbusCollectionsTests-Info.plist"; path = "unittests/NimbusCollectionsTests-Info.plist"; sourceTree = "<group>"; };
+		D5E59299221245200076B697 /* NIAttributedLabel+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NIAttributedLabel+Testing.h"; sourceTree = "<group>"; };
 		DB3A230913FD4B8E00614220 /* libNimbusAttributedLabel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libNimbusAttributedLabel.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB3A231613FD4B8E00614220 /* NimbusAttributedLabelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NimbusAttributedLabelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB3A233213FD4BE500614220 /* NIAttributedLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NIAttributedLabel.h; sourceTree = "<group>"; };
@@ -2095,6 +2097,7 @@
 			children = (
 				DB3A233413FD4BE500614220 /* NimbusAttributedLabel.h */,
 				DB3A233213FD4BE500614220 /* NIAttributedLabel.h */,
+				D5E59299221245200076B697 /* NIAttributedLabel+Testing.h */,
 				DB3A233313FD4BE500614220 /* NIAttributedLabel.m */,
 				6693C2F3158BB8E900950D42 /* NSMutableAttributedString+NimbusAttributedLabel.h */,
 				6693C2F4158BB8E900950D42 /* NSMutableAttributedString+NimbusAttributedLabel.m */,
@@ -2324,6 +2327,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5E5929D221246140076B697 /* NIAttributedLabel+Testing.h in Headers */,
 				DB3A233613FD4BE500614220 /* NIAttributedLabel.h in Headers */,
 				DB3A233813FD4BE500614220 /* NimbusAttributedLabel.h in Headers */,
 			);

--- a/src/attributedlabel/src/NIAttributedLabel+Testing.h
+++ b/src/attributedlabel/src/NIAttributedLabel+Testing.h
@@ -1,0 +1,36 @@
+//
+// Copyright 2011-2014 NimbusKit
+// Originally created by Roger Chapman
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "NIAttributedLabel.h"
+
+/**
+ * A category exposing methods that are exercised by unit tests.
+ */
+@interface NIAttributedLabel (Testing)
+
+/**
+ * The text checking result for the link that is currently being touched or nil if no link is
+ * being touched.
+ */
+@property (nonatomic, strong) NSTextCheckingResult *touchedLink;
+
+/**
+ * An internal method that is called when the user long presses on a link.
+ */
+- (void)_longPressTimerDidFire:(NSTimer *)timer;
+
+@end

--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -166,9 +166,26 @@ extern NSString* const NIAttributedLabelLinkAttributeName; // Value is an NSText
 - (void)attributedLabel:(NIAttributedLabel *)attributedLabel didSelectTextCheckingResult:(NSTextCheckingResult *)result atPoint:(CGPoint)point;
 
 /**
+ * Informs the receiver that a data detector result has been long pressed.
+ *
+ * If this method is implemented by the receiver then
+ * -attributedLabel:shouldPresentActionSheet:withTextCheckingResult:atPoint: will not be called
+ * and no action sheet will be presented when long pressing a data detector result.
+ *
+ * @param attributedLabel An attributed label informing the receiver of the selection.
+ * @param result The data detector result that was long pressed.
+ * @param point The point within @c attributedLabel where the result was long pressed.
+ */
+- (void)attributedLabel:(NIAttributedLabel *)attributedLabel didLongPressTextCheckingResult:(NSTextCheckingResult *)result atPoint:(CGPoint)point;
+
+/**
  * Asks the receiver whether an action sheet should be displayed at the given point.
  *
- * If this method is not implemented by the receiver then @c actionSheet will always be displayed.
+ * If -attributedLabel:didLongPressTextCheckingResult:atPoint: is implemented by the receiver, this
+ * delegate method will not be called and no action sheet will be displayed. If neither
+ * -attributedLabel:didLongPressTextCheckingResult:atPoint: nor
+ * -attributedLabel:shouldPresentActionSheet:withTextCheckingResult:atPoint: are implemented by the
+ * receiver, @c actionSheet will always be displayed.
  *
  * @c actionSheet will be populated with actions that match the data type that was selected. For
  * example, a link will have the actions "Open in Safari" and "Copy URL". A phone number will have
@@ -182,7 +199,7 @@ extern NSString* const NIAttributedLabelLinkAttributeName; // Value is an NSText
  * @returns YES if @c actionSheet should be displayed. NO if @c actionSheet should not be
  *               displayed.
  */
-- (BOOL)attributedLabel:(NIAttributedLabel *)attributedLabel shouldPresentActionSheet:(UIActionSheet *)actionSheet withTextCheckingResult:(NSTextCheckingResult *)result atPoint:(CGPoint)point NS_DEPRECATED_IOS(2_0, 8_3);
+- (BOOL)attributedLabel:(NIAttributedLabel *)attributedLabel shouldPresentActionSheet:(UIActionSheet *)actionSheet withTextCheckingResult:(NSTextCheckingResult *)result atPoint:(CGPoint)point NS_DEPRECATED_IOS(2_0, 8_3, "UIActionSheet is deprecated. Use -attributedLabel:didLongPressTextCheckingResult:atPoint: and UIAlertController with a preferredStyle of UIAlertControllerStyleActionSheet instead");
 
 @end
 

--- a/src/attributedlabel/unittests/NIAttributedLabelTests.m
+++ b/src/attributedlabel/unittests/NIAttributedLabelTests.m
@@ -16,9 +16,41 @@
 
 // See: http://bit.ly/hS5nNh for unit test macros.
 
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
 #import "NimbusAttributedLabel.h"
+#import "NIAttributedLabel+Testing.h"
+
+@interface NIAttributedLabelTestMonitor : NSObject <NIAttributedLabelDelegate>
+
+@property(nonatomic, assign) BOOL doNotRespondToLongPressCallback;
+
+@property(nonatomic, readonly) int longPressCallbackCount;
+@property(nonatomic, readonly) int actionSheetCallbackCount;
+
+@end
+
+@implementation NIAttributedLabelTestMonitor
+
+- (BOOL)respondsToSelector:(SEL)selector {
+  if (selector == @selector(attributedLabel:didLongPressTextCheckingResult:atPoint:)) {
+    return !_doNotRespondToLongPressCallback;
+  }
+
+  return [super respondsToSelector:selector];
+}
+
+- (void)attributedLabel:(NIAttributedLabel *)attributedLabel didLongPressTextCheckingResult:(NSTextCheckingResult *)result atPoint:(CGPoint)point {
+  _longPressCallbackCount++;
+}
+
+- (BOOL)attributedLabel:(NIAttributedLabel *)attributedLabel shouldPresentActionSheet:(UIActionSheet *)actionSheet withTextCheckingResult:(NSTextCheckingResult *)result atPoint:(CGPoint)point {
+  _actionSheetCallbackCount++;
+  return NO;
+}
+
+@end
 
 @interface NIAttributedLabelTests : XCTestCase
 @end
@@ -26,8 +58,55 @@
 
 @implementation NIAttributedLabelTests
 
+- (void)testLongPressCallbackOverridesActionSheetCallbackWhenTouchingLink {
+  // Create an attributed string with a link.
+  NSString *string = @"NimbusKit";
+  NSURL *URL = [NSURL URLWithString:@"http://nimbuskit.info/"];
+  NSTextCheckingResult *textCheckingResult = [NSTextCheckingResult linkCheckingResultWithRange:NSMakeRange(0, string.length) URL:URL];
+  NSDictionary<NSAttributedStringKey, id> *attributes = @{ NIAttributedLabelLinkAttributeName : textCheckingResult };
+  NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:string attributes:attributes];
 
-- (void)testNothing {
+  // Create a label.
+  NIAttributedLabel *label = [[NIAttributedLabel alloc] initWithFrame:CGRectMake(0, 0, 200, 200)];
+  label.attributedText = attributedText;
+
+  // Create a monitor for attributed label callbacks.
+  NIAttributedLabelTestMonitor *monitor = [[NIAttributedLabelTestMonitor alloc] init];
+  label.delegate = monitor;
+
+  // Simulate touching a link.
+  label.touchedLink = textCheckingResult;
+  [label _longPressTimerDidFire:nil];
+
+  // Verify expected callbacks.
+  XCTAssertEqual(monitor.longPressCallbackCount, 1);
+  XCTAssertEqual(monitor.actionSheetCallbackCount, 0);
+}
+
+- (void)testActionSheetCallbackDeliveredWhenTouchingLink {
+  // Create an attributed string with a link.
+  NSString *string = @"NimbusKit";
+  NSURL *URL = [NSURL URLWithString:@"http://nimbuskit.info/"];
+  NSTextCheckingResult *textCheckingResult = [NSTextCheckingResult linkCheckingResultWithRange:NSMakeRange(0, string.length) URL:URL];
+  NSDictionary<NSAttributedStringKey, id> *attributes = @{ NIAttributedLabelLinkAttributeName : textCheckingResult };
+  NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:string attributes:attributes];
+
+  // Create a label.
+  NIAttributedLabel *label = [[NIAttributedLabel alloc] initWithFrame:CGRectMake(0, 0, 200, 200)];
+  label.attributedText = attributedText;
+
+  // Create a monitor for attributed label callbacks and make it not respond to the long press callback.
+  NIAttributedLabelTestMonitor *monitor = [[NIAttributedLabelTestMonitor alloc] init];
+  monitor.doNotRespondToLongPressCallback = YES;
+  label.delegate = monitor;
+
+  // Simulate touching a link.
+  label.touchedLink = textCheckingResult;
+  [label _longPressTimerDidFire:nil];
+
+  // Verify expected callbacks.
+  XCTAssertEqual(monitor.longPressCallbackCount, 0);
+  XCTAssertEqual(monitor.actionSheetCallbackCount, 1);
 }
 
 @end


### PR DESCRIPTION
This change introduces a new delegate method,
-attributedLabel:didLongPressTextCheckingResult:atPoint:, which is used
to detect when a user long presses on a data detector result. This
delegate method enables projects to avoid the creation of UIActionSheet
objects (the UIActionSheet class is deprecated) and avoid implementing
-attributedLabel:shouldPresentActionSheet:withTextCheckingResult:atPoint:
which contains the deprecated type in its signature. Clients can
implement -attributedLabel:didLongPressTextCheckingResult:atPoint: and
present a UIAlertController appropriately. It is not appropriate for
NIAttributedLabel to attempt to determine an appropriate position in the
view controller hierarchy from which to present a UIAlertController.
The user interaction **must** be delegated to an object that has
appropriate access to the view controller hierarchy to properly present
a UIAlertController. As this new delegate method represents the
migration path away from legacy UIActionSheet presentation, responding
to this selector is treated as opting out of action sheet presentation
and overrides
-attributedLabel:shouldPresentActionSheet:withTextCheckingResult:atPoint:.

This change also introduces a testing header and some tests to verify
the desired delegate callback behaviors.

Tested by running tests with iPhone XR simulator running iOS 12.1.