### PR TITLE
remove semicolons

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -49,7 +49,7 @@ CGSize NISizeOfAttributedStringConstrainedToSize(NSAttributedString* attributedS
 void NIAttributedLabelEnableSingleLineSizeCalculationFix(void);
 
 #if defined __cplusplus
-};
+}
 #endif
 
 // Vertical alignments for NIAttributedLabel.

--- a/src/core/src/NIActions.h
+++ b/src/core/src/NIActions.h
@@ -140,7 +140,7 @@ extern "C" {
 NIActionBlock NIPushControllerAction(Class controllerClass);
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /** The protocol for a data source that can be used with NIActions. */

--- a/src/core/src/NIButtonUtilities.h
+++ b/src/core/src/NIButtonUtilities.h
@@ -88,5 +88,5 @@ void NIApplyTitleColorSelectorToButton(SEL selector, id target, UIButton* button
 /**@}*/// End of Button Utilities /////////////////////////////////////////////////////////////////
 
 #if defined __cplusplus
-};
+}
 #endif

--- a/src/core/src/NICommonMetrics.h
+++ b/src/core/src/NICommonMetrics.h
@@ -166,7 +166,7 @@ NSTimeInterval NIDeviceRotationDuration(BOOL isFlippingUpsideDown);
 UIEdgeInsets NICellContentPadding(void);
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /**@}*/// End of Common Metrics ///////////////////////////////////////////////////////////////////

--- a/src/core/src/NIDeviceOrientation.h
+++ b/src/core/src/NIDeviceOrientation.h
@@ -85,7 +85,7 @@ BOOL NIIsLandscapePhoneOrientation(UIInterfaceOrientation orientation);
 CGAffineTransform NIRotateTransformForOrientation(UIInterfaceOrientation orientation);
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /**@}*/// End of Device Orientation ///////////////////////////////////////////////////////////////

--- a/src/core/src/NIFoundationMethods.h
+++ b/src/core/src/NIFoundationMethods.h
@@ -420,7 +420,7 @@ NSInteger NIBoundi(NSInteger value, NSInteger min, NSInteger max);
 /**@}*/
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /**@}*/// End of Foundation Methods ///////////////////////////////////////////////////////////////

--- a/src/core/src/NIImageUtilities.h
+++ b/src/core/src/NIImageUtilities.h
@@ -44,5 +44,5 @@ UIImage* NIStretchableImageFromImage(UIImage* image);
 /**@}*/// End of Image Utilities //////////////////////////////////////////////////////////////////
 
 #if defined __cplusplus
-};
+}
 #endif

--- a/src/core/src/NINetworkActivity.h
+++ b/src/core/src/NINetworkActivity.h
@@ -95,7 +95,7 @@ void NIDisableNetworkActivityDebugging(void);
 /**@}*/// End of For Debugging Only
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /**@}*/// End of Network Activity /////////////////////////////////////////////////////////////////

--- a/src/core/src/NINonEmptyCollectionTesting.h
+++ b/src/core/src/NINonEmptyCollectionTesting.h
@@ -52,7 +52,7 @@ BOOL NIIsSetWithObjects(id object);
 BOOL NIIsStringWithAnyText(id object);
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /**@}*/// End of Non-Empty Collection Testing /////////////////////////////////////////////////////

--- a/src/core/src/NINonRetainingCollections.h
+++ b/src/core/src/NINonRetainingCollections.h
@@ -59,7 +59,7 @@ NSMutableDictionary* NICreateNonRetainingMutableDictionary(void);
 NSMutableSet* NICreateNonRetainingMutableSet(void);
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /**@}*/// End of Non-Retaining Collections ////////////////////////////////////////////////////////

--- a/src/core/src/NIPaths.h
+++ b/src/core/src/NIPaths.h
@@ -63,7 +63,7 @@ NSString* NIPathForLibraryResource(NSString* relativePath);
 NSString* NIPathForCachesResource(NSString* relativePath);
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /**@}*/// End of Paths ////////////////////////////////////////////////////////////////////////////

--- a/src/core/src/NIRuntimeClassModifications.h
+++ b/src/core/src/NIRuntimeClassModifications.h
@@ -68,7 +68,7 @@ void NISwapInstanceMethods(Class cls, SEL originalSel, SEL newSel);
 void NISwapClassMethods(Class cls, SEL originalSel, SEL newSel);
 
 #if defined __cplusplus
-};
+}
 #endif
 
 /**@}*/// End of Runtime Class Modifications //////////////////////////////////////////////////////


### PR DESCRIPTION
Remove extra semicolons from all extern C macros.

This will make it easier to use for compilers with strict rules against extra semicolons