### PR TITLE
Extract the interfaces of NICollectionViewModel and NIMutableCollectionViewModel out into protocols named NICollectionViewModel and NIMutableCollectionViewModel respectively

### DIFF
--- a/src/collections/src/NICollectionViewCellFactory.h
+++ b/src/collections/src/NICollectionViewCellFactory.h
@@ -59,7 +59,7 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
  * the object to a cell it will return nil.
  *
  * @code
-- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
+- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModeling>)collectionViewModel
                         cellForCollectionView:(UICollectionView *)collectionView
                                   atIndexPath:(NSIndexPath *)indexPath
                                    withObject:(id)object {
@@ -74,7 +74,7 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
 }
  * @endcode
  */
-+ (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel cellForCollectionView:(UICollectionView *)collectionView atIndexPath:(NSIndexPath *)indexPath withObject:(id)object;
++ (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModeling>)collectionViewModel cellForCollectionView:(UICollectionView *)collectionView atIndexPath:(NSIndexPath *)indexPath withObject:(id)object;
 
 /**
  * Map an object's class to a cell's class.
@@ -94,7 +94,7 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
  * can fetch the cell class and then perform any selectors that are necessary for calculating the
  * dimensions of the cell before it is instantiated.
  */
-- (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModel>)model;
+- (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModeling>)model;
 
 /**
  * Returns the mapped cell class for an object at a given index path.
@@ -103,7 +103,7 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
  * can fetch the cell class and then perform any selectors that are necessary for calculating the
  * dimensions of the cell before it is instantiated.
  */
-+ (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModel>)model;
++ (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModeling>)model;
 
 @end
 

--- a/src/collections/src/NICollectionViewCellFactory.h
+++ b/src/collections/src/NICollectionViewCellFactory.h
@@ -59,7 +59,7 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
  * the object to a cell it will return nil.
  *
  * @code
-- (UICollectionViewCell *)collectionViewModel:(NICollectionViewModel *)collectionViewModel
+- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
                         cellForCollectionView:(UICollectionView *)collectionView
                                   atIndexPath:(NSIndexPath *)indexPath
                                    withObject:(id)object {
@@ -74,7 +74,7 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
 }
  * @endcode
  */
-+ (UICollectionViewCell *)collectionViewModel:(NICollectionViewModel *)collectionViewModel cellForCollectionView:(UICollectionView *)collectionView atIndexPath:(NSIndexPath *)indexPath withObject:(id)object;
++ (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel cellForCollectionView:(UICollectionView *)collectionView atIndexPath:(NSIndexPath *)indexPath withObject:(id)object;
 
 /**
  * Map an object's class to a cell's class.
@@ -94,7 +94,7 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
  * can fetch the cell class and then perform any selectors that are necessary for calculating the
  * dimensions of the cell before it is instantiated.
  */
-- (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(NICollectionViewModel *)model;
+- (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModel>)model;
 
 /**
  * Returns the mapped cell class for an object at a given index path.
@@ -103,7 +103,7 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
  * can fetch the cell class and then perform any selectors that are necessary for calculating the
  * dimensions of the cell before it is instantiated.
  */
-+ (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(NICollectionViewModel *)model;
++ (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModel>)model;
 
 @end
 

--- a/src/collections/src/NICollectionViewCellFactory.m
+++ b/src/collections/src/NICollectionViewCellFactory.m
@@ -84,7 +84,7 @@
   return cell;
 }
 
-+ (UICollectionViewCell *)collectionViewModel:(NICollectionViewModel *)collectionViewModel
++ (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
                         cellForCollectionView:(UICollectionView *)collectionView
                                   atIndexPath:(NSIndexPath *)indexPath
                                    withObject:(id)object {
@@ -129,7 +129,7 @@
   return collectionViewCellClass;
 }
 
-- (UICollectionViewCell *)collectionViewModel:(NICollectionViewModel *)collectionViewModel
+- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
                    cellForCollectionView:(UICollectionView *)collectionView
                         atIndexPath:(NSIndexPath *)indexPath
                          withObject:(id)object {
@@ -157,12 +157,12 @@
   [self.objectToCellMap setObject:collectionViewCellClass forKey:(id<NSCopying>)objectClass];
 }
 
-- (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(NICollectionViewModel *)model {
+- (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModel>)model {
   id object = [model objectAtIndexPath:indexPath];
   return [self collectionViewCellClassFromObject:object];
 }
 
-+ (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(NICollectionViewModel *)model {
++ (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModel>)model {
   id object = [model objectAtIndexPath:indexPath];
   Class collectionViewCellClass = nil;
   if ([object respondsToSelector:@selector(collectionViewCellClass)]) {

--- a/src/collections/src/NICollectionViewCellFactory.m
+++ b/src/collections/src/NICollectionViewCellFactory.m
@@ -84,7 +84,7 @@
   return cell;
 }
 
-+ (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
++ (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModeling>)collectionViewModel
                         cellForCollectionView:(UICollectionView *)collectionView
                                   atIndexPath:(NSIndexPath *)indexPath
                                    withObject:(id)object {
@@ -129,7 +129,7 @@
   return collectionViewCellClass;
 }
 
-- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
+- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModeling>)collectionViewModel
                    cellForCollectionView:(UICollectionView *)collectionView
                         atIndexPath:(NSIndexPath *)indexPath
                          withObject:(id)object {
@@ -157,12 +157,12 @@
   [self.objectToCellMap setObject:collectionViewCellClass forKey:(id<NSCopying>)objectClass];
 }
 
-- (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModel>)model {
+- (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModeling>)model {
   id object = [model objectAtIndexPath:indexPath];
   return [self collectionViewCellClassFromObject:object];
 }
 
-+ (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModel>)model {
++ (Class)collectionViewCellClassForItemAtIndexPath:(NSIndexPath *)indexPath model:(id<NICollectionViewModeling>)model {
   id object = [model objectAtIndexPath:indexPath];
   Class collectionViewCellClass = nil;
   if ([object respondsToSelector:@selector(collectionViewCellClass)]) {

--- a/src/collections/src/NICollectionViewModel.h
+++ b/src/collections/src/NICollectionViewModel.h
@@ -41,7 +41,7 @@
  *
  * @ingroup CollectionViewModels
  */
-@protocol NICollectionViewModel <NIActionsDataSource, UICollectionViewDataSource>
+@protocol NICollectionViewModeling <NIActionsDataSource, UICollectionViewDataSource>
 
 #pragma mark Creating Collection View Models
 
@@ -63,7 +63,7 @@
 
 /**
  * A non-mutable collection view model object that provides a lightweight implementation of
- * the NICollectionViewModel protocol.
+ * the NICollectionViewModeling protocol.
  *
  * This base class is non-mutable, much like an NSArray. You must initialize this model with
  * the contents when you create it.
@@ -73,7 +73,7 @@
  *
  * @ingroup CollectionViewModels
  */
-@interface NICollectionViewModel : NSObject <NICollectionViewModel>
+@interface NICollectionViewModel : NSObject <NICollectionViewModeling>
 
 // Redeclaring for property autosynthesis.
 @property (nonatomic, weak) id<NICollectionViewModelDelegate> delegate;
@@ -93,7 +93,7 @@
  *
  * The implementation of this method will generally use object to customize the cell.
  */
-- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
+- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModeling>)collectionViewModel
                         cellForCollectionView:(UICollectionView *)collectionView
                                   atIndexPath:(NSIndexPath *)indexPath
                                    withObject:(id)object;
@@ -106,7 +106,7 @@
  * The value of the kind property and indexPath are implementation-dependent
  * based on the type of UICollectionViewLayout being used.
  */
-- (UICollectionReusableView *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
+- (UICollectionReusableView *)collectionViewModel:(id<NICollectionViewModeling>)collectionViewModel
                                    collectionView:(UICollectionView *)collectionView
                 viewForSupplementaryElementOfKind:(NSString *)kind
                                       atIndexPath:(NSIndexPath *)indexPath;

--- a/src/collections/src/NICollectionViewModel.h
+++ b/src/collections/src/NICollectionViewModel.h
@@ -28,6 +28,26 @@
 // Classes used when creating NICollectionViewModels.
 @class NICollectionViewModelFooter;  // Provides the information for a footer.
 
+@protocol NICollectionViewModel <NIActionsDataSource, UICollectionViewDataSource>
+
+#pragma mark Creating Collection View Models
+
+// Designated initializer.
+- (id)initWithDelegate:(id<NICollectionViewModelDelegate>)delegate;
+- (id)initWithListArray:(NSArray *)listArray delegate:(id<NICollectionViewModelDelegate>)delegate;
+// Each NSString in the array starts a new section. Any other object is a new row (with exception of certain model-specific objects).
+- (id)initWithSectionedArray:(NSArray *)sectionedArray delegate:(id<NICollectionViewModelDelegate>)delegate;
+
+#pragma mark Accessing Objects
+
+- (NSIndexPath *)indexPathForObject:(id)object;
+
+#pragma mark Creating Collection View Cells
+
+@property (nonatomic, weak) id<NICollectionViewModelDelegate> delegate;
+
+@end
+
 /**
  * A non-mutable collection view model that complies to the UICollectionViewDataSource protocol.
  *
@@ -42,25 +62,7 @@
  *
  * @ingroup CollectionViewModels
  */
-@interface NICollectionViewModel : NSObject <NIActionsDataSource, UICollectionViewDataSource>
-
-#pragma mark Creating Collection View Models
-
-// Designated initializer.
-- (id)initWithDelegate:(id<NICollectionViewModelDelegate>)delegate;
-- (id)initWithListArray:(NSArray *)listArray delegate:(id<NICollectionViewModelDelegate>)delegate;
-// Each NSString in the array starts a new section. Any other object is a new row (with exception of certain model-specific objects).
-- (id)initWithSectionedArray:(NSArray *)sectionedArray delegate:(id<NICollectionViewModelDelegate>)delegate;
-
-#pragma mark Accessing Objects
-
-// This method is not appropriate for performance critical codepaths.
-- (NSIndexPath *)indexPathForObject:(id)object;
-
-#pragma mark Creating Collection View Cells
-
-@property (nonatomic, weak) id<NICollectionViewModelDelegate> delegate;
-
+@interface NICollectionViewModel : NSObject <NICollectionViewModel>
 @end
 
 /**
@@ -76,7 +78,7 @@
  *
  * The implementation of this method will generally use object to customize the cell.
  */
-- (UICollectionViewCell *)collectionViewModel:(NICollectionViewModel *)collectionViewModel
+- (UICollectionViewCell *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
                         cellForCollectionView:(UICollectionView *)collectionView
                                   atIndexPath:(NSIndexPath *)indexPath
                                    withObject:(id)object;
@@ -89,7 +91,7 @@
  * The value of the kind property and indexPath are implementation-dependent
  * based on the type of UICollectionViewLayout being used.
  */
-- (UICollectionReusableView *)collectionViewModel:(NICollectionViewModel *)collectionViewModel
+- (UICollectionReusableView *)collectionViewModel:(id<NICollectionViewModel>)collectionViewModel
                                    collectionView:(UICollectionView *)collectionView
                 viewForSupplementaryElementOfKind:(NSString *)kind
                                       atIndexPath:(NSIndexPath *)indexPath;

--- a/src/collections/src/NICollectionViewModel.h
+++ b/src/collections/src/NICollectionViewModel.h
@@ -28,6 +28,19 @@
 // Classes used when creating NICollectionViewModels.
 @class NICollectionViewModelFooter;  // Provides the information for a footer.
 
+/**
+ * A protocol that declares the interface for a non-mutable collection view model.
+ *
+ * A default implementation of this protocol is provided with the NICollectionViewModel class.
+ * If you want to customize the implementation of your collection view model while keeping the base
+ * interface the same, conform to this protocol and implement the declared methods at minimum.
+ *
+ * The model class that conforms to this protocol is intended to allow you to easily create a data
+ * source for a UICollectionView without having to implement the UICollectionViewDataSource methods
+ * in your controller.
+ *
+ * @ingroup CollectionViewModels
+ */
 @protocol NICollectionViewModel <NIActionsDataSource, UICollectionViewDataSource>
 
 #pragma mark Creating Collection View Models
@@ -49,10 +62,8 @@
 @end
 
 /**
- * A non-mutable collection view model that complies to the UICollectionViewDataSource protocol.
- *
- * This model allows you to easily create a data source for a UICollectionView without having to
- * implement the UICollectionViewDataSource methods in your controller.
+ * A non-mutable collection view model object that provides a lightweight implementation of
+ * the NICollectionViewModel protocol.
  *
  * This base class is non-mutable, much like an NSArray. You must initialize this model with
  * the contents when you create it.
@@ -63,6 +74,10 @@
  * @ingroup CollectionViewModels
  */
 @interface NICollectionViewModel : NSObject <NICollectionViewModel>
+
+// Redeclaring for property autosynthesis.
+@property (nonatomic, weak) id<NICollectionViewModelDelegate> delegate;
+
 @end
 
 /**

--- a/src/collections/src/NIMutableCollectionViewModel.h
+++ b/src/collections/src/NIMutableCollectionViewModel.h
@@ -16,6 +16,20 @@
 
 #import "NICollectionViewModel.h"
 
+@protocol NIMutableCollectionViewModel <NICollectionViewModel>
+
+- (NSArray *)addObject:(id)object;
+- (NSArray *)addObject:(id)object toSection:(NSUInteger)section;
+- (NSArray *)addObjectsFromArray:(NSArray *)array;
+- (NSArray *)insertObject:(id)object atRow:(NSUInteger)row inSection:(NSUInteger)section;
+- (NSArray *)removeObjectAtIndexPath:(NSIndexPath *)indexPath;
+
+- (NSIndexSet *)addSectionWithTitle:(NSString *)title;
+- (NSIndexSet *)insertSectionWithTitle:(NSString *)title atIndex:(NSUInteger)index;
+- (NSIndexSet *)removeSectionAtIndex:(NSUInteger)index;
+
+@end
+
 /**
  * The NIMutableCollectionViewModel class is a mutable collection view model.
  *
@@ -45,17 +59,6 @@
  * @ingroup TableViewModels
  */
 @interface NIMutableCollectionViewModel : NICollectionViewModel
-
-- (NSArray *)addObject:(id)object;
-- (NSArray *)addObject:(id)object toSection:(NSUInteger)section;
-- (NSArray *)addObjectsFromArray:(NSArray *)array;
-- (NSArray *)insertObject:(id)object atRow:(NSUInteger)row inSection:(NSUInteger)section;
-- (NSArray *)removeObjectAtIndexPath:(NSIndexPath *)indexPath;
-
-- (NSIndexSet *)addSectionWithTitle:(NSString *)title;
-- (NSIndexSet *)insertSectionWithTitle:(NSString *)title atIndex:(NSUInteger)index;
-- (NSIndexSet *)removeSectionAtIndex:(NSUInteger)index;
-
 @end
 
 /** @name Modifying Objects */

--- a/src/collections/src/NIMutableCollectionViewModel.h
+++ b/src/collections/src/NIMutableCollectionViewModel.h
@@ -49,7 +49,7 @@
  *
  * @ingroup CollectionViewModels
  */
-@protocol NIMutableCollectionViewModel <NICollectionViewModel>
+@protocol NIMutableCollectionViewModeling <NICollectionViewModeling>
 
 - (NSArray *)addObject:(id)object;
 - (NSArray *)addObject:(id)object toSection:(NSUInteger)section;
@@ -65,11 +65,11 @@
 
 /**
  * A non-mutable collection view model object that provides a lightweight implementation of
- * the NIMutableCollectionViewModel protocol.
+ * the NIMutableCollectionViewModeling protocol.
  *
  * @ingroup CollectionViewModels
  */
-@interface NIMutableCollectionViewModel : NICollectionViewModel <NIMutableCollectionViewModel>
+@interface NIMutableCollectionViewModel : NICollectionViewModel <NIMutableCollectionViewModeling>
 @end
 
 /** @name Modifying Objects */

--- a/src/collections/src/NIMutableCollectionViewModel.h
+++ b/src/collections/src/NIMutableCollectionViewModel.h
@@ -16,29 +16,20 @@
 
 #import "NICollectionViewModel.h"
 
-@protocol NIMutableCollectionViewModel <NICollectionViewModel>
-
-- (NSArray *)addObject:(id)object;
-- (NSArray *)addObject:(id)object toSection:(NSUInteger)section;
-- (NSArray *)addObjectsFromArray:(NSArray *)array;
-- (NSArray *)insertObject:(id)object atRow:(NSUInteger)row inSection:(NSUInteger)section;
-- (NSArray *)removeObjectAtIndexPath:(NSIndexPath *)indexPath;
-
-- (NSIndexSet *)addSectionWithTitle:(NSString *)title;
-- (NSIndexSet *)insertSectionWithTitle:(NSString *)title atIndex:(NSUInteger)index;
-- (NSIndexSet *)removeSectionAtIndex:(NSUInteger)index;
-
-@end
-
 /**
- * The NIMutableCollectionViewModel class is a mutable collection view model.
+ * A protocol that declares the interface for a mutable collection view model.
+ *
+ * A default implementation of this protocol is provided with the NIMutableCollectionViewModel
+ * class. If you want to customize the implementation of your collection view model while keeping
+ * the base interface the same, conform to this protocol and implement the declared methods at
+ * minimum.
  *
  * When modifications are made to the model there are two ways to reflect the changes in the
  * collection view.
  *
  * - Call reloadData on the collection view. This is the most destructive way to update the
  *   collection view.
- * - Call insert/delete/reload methods on the collection view with the retuned index path arrays.
+ * - Call insert/delete/reload methods on the collection view with the returned index path arrays.
  *
  * The latter option is the recommended approach to adding new cells to a collection view. Each
  * method in the mutable collection view model returns a data structure that can be used to inform
@@ -56,9 +47,29 @@
  [self.collectionView insertSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
  @endcode
  *
- * @ingroup TableViewModels
+ * @ingroup CollectionViewModels
  */
-@interface NIMutableCollectionViewModel : NICollectionViewModel
+@protocol NIMutableCollectionViewModel <NICollectionViewModel>
+
+- (NSArray *)addObject:(id)object;
+- (NSArray *)addObject:(id)object toSection:(NSUInteger)section;
+- (NSArray *)addObjectsFromArray:(NSArray *)array;
+- (NSArray *)insertObject:(id)object atRow:(NSUInteger)row inSection:(NSUInteger)section;
+- (NSArray *)removeObjectAtIndexPath:(NSIndexPath *)indexPath;
+
+- (NSIndexSet *)addSectionWithTitle:(NSString *)title;
+- (NSIndexSet *)insertSectionWithTitle:(NSString *)title atIndex:(NSUInteger)index;
+- (NSIndexSet *)removeSectionAtIndex:(NSUInteger)index;
+
+@end
+
+/**
+ * A non-mutable collection view model object that provides a lightweight implementation of
+ * the NIMutableCollectionViewModel protocol.
+ *
+ * @ingroup CollectionViewModels
+ */
+@interface NIMutableCollectionViewModel : NICollectionViewModel <NIMutableCollectionViewModel>
 @end
 
 /** @name Modifying Objects */


### PR DESCRIPTION
This approach makes it easier to extend the Nimbus collection model pattern without being restricted by the Nimbus collection models' implementation.