### PR TITLE
Allow objects to provide suffixes to their cell's reuse identifier.

### DIFF
--- a/src/collections/src/NICollectionViewCellFactory.h
+++ b/src/collections/src/NICollectionViewCellFactory.h
@@ -177,7 +177,12 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
  */
 @protocol NICollectionViewCellReuseIdentifierExtension <NSObject>
 
-/** A unique reuse identifier suffix to append to the reuse identifier of the cell. */
+/**
+ * A unique reuse identifier suffix to append to the reuse identifier of the cell.
+ *
+ * @note Classes conforming to this protocol may return nil or the empty string to opt out of the
+ * suffix.
+ */
 - (NSString *)reuseIdentifierSuffix;
 
 @end

--- a/src/collections/src/NICollectionViewCellFactory.h
+++ b/src/collections/src/NICollectionViewCellFactory.h
@@ -167,6 +167,22 @@ _model.delegate = (id)[NICollectionViewCellFactory class];
 @end
 
 /**
+ * A protocol that objects may conform to in order to provide a custom suffix to the reuse
+ * identifier of its cell.
+ *
+ * This is useful for objects that can support different configurations, such that cells updated
+ * with an instance of the object can be reused only for objects supporting the same configuration.
+ * This can be used as an optimization for objects that support dynamic configurations that would be
+ * inefficient to reset during -prepareForReuse.
+ */
+@protocol NICollectionViewCellReuseIdentifierExtension <NSObject>
+
+/** A unique reuse identifier suffix to append to the reuse identifier of the cell. */
+- (NSString *)reuseIdentifierSuffix;
+
+@end
+
+/**
  * A light-weight implementation of the NICollectionViewCellObject protocol.
  *
  * Use this object in cases where you can't set up a hard binding between an object and a cell,

--- a/src/collections/src/NICollectionViewCellFactory.m
+++ b/src/collections/src/NICollectionViewCellFactory.m
@@ -53,6 +53,13 @@
     identifier = [identifier stringByAppendingFormat:@".%@", NSStringFromClass([object class])];
   }
 
+  if ([object respondsToSelector:@selector(reuseIdentifierSuffix)]) {
+    NSString* suffix = [object reuseIdentifierSuffix];
+    if (suffix.length) {
+      identifier = [identifier stringByAppendingFormat:@".%@", suffix];
+    }
+  }
+
   [collectionView registerClass:collectionViewCellClass forCellWithReuseIdentifier:identifier];
 
   cell = [collectionView dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:indexPath];
@@ -72,6 +79,14 @@
   UICollectionViewCell* cell = nil;
 
   NSString* identifier = NSStringFromClass([object class]);
+
+  if ([object respondsToSelector:@selector(reuseIdentifierSuffix)]) {
+    NSString* suffix = [object reuseIdentifierSuffix];
+    if (suffix.length) {
+      identifier = [identifier stringByAppendingFormat:@".%@", suffix];
+    }
+  }
+
   [collectionView registerNib:collectionViewCellNib forCellWithReuseIdentifier:identifier];
 
   cell = [collectionView dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:indexPath];


### PR DESCRIPTION
This is a useful optimization for objects that support various
configurations or dynamic content layouts. Without this, it's very
inefficient to do cell reuse without significant work in
-prepareForReuse for the content view.

This change allows objects to add custom suffixes to make unique
identifiers for objects with identical layouts to allow for efficient
view reuse for cells housing content views of the same layout.