### PR TITLE
NIPhotoScrollView: Move centering logic to scrollViewDidZoom: to avoid layout in unexpected timing

### DIFF
--- a/src/photos/src/NIPhotoScrollView.m
+++ b/src/photos/src/NIPhotoScrollView.m
@@ -461,8 +461,6 @@
   self.frame = frame;
   [self setMaxMinZoomScalesForCurrentBounds];
   [self restoreCenterPoint:restorePoint scale:restoreScale];
-
-  [_scrollView setNeedsLayout];
 }
 
 #pragma mark Centering

--- a/src/photos/src/NIPhotoScrollView.m
+++ b/src/photos/src/NIPhotoScrollView.m
@@ -24,52 +24,6 @@
 #error "Nimbus requires ARC support."
 #endif
 
-/**
- * A UIScrollView that centers the zooming view's frame as the user zooms.
- *
- * We must update the zooming view's frame within the scroll view's layoutSubviews,
- * thus why we've subclassed UIScrollView.
- */
-@interface NICenteringScrollView : UIScrollView
-@end
-
-
-@implementation NICenteringScrollView
-
-
-#pragma mark - UIView
-
-
-- (void)layoutSubviews {
-  [super layoutSubviews];
-
-  // Center the image as it becomes smaller than the size of the screen.
-
-  UIView* zoomingSubview = [self.delegate viewForZoomingInScrollView:self];
-  CGSize boundsSize = self.bounds.size;
-  CGRect frameToCenter = zoomingSubview.frame;
-  
-  // Center horizontally.
-  if (frameToCenter.size.width < boundsSize.width) {
-    frameToCenter.origin.x = NICGFloatFloor((boundsSize.width - frameToCenter.size.width) / 2);
-
-  } else {
-    frameToCenter.origin.x = 0;
-  }
-
-  // Center vertically.
-  if (frameToCenter.size.height < boundsSize.height) {
-    frameToCenter.origin.y = NICGFloatFloor((boundsSize.height - frameToCenter.size.height) / 2);
-
-  } else {
-    frameToCenter.origin.y = 0;
-  }
-
-  zoomingSubview.frame = frameToCenter;
-}
-
-@end
-
 @interface NIPhotoScrollView ()
 @property (nonatomic, assign) NIPhotoScrollViewPhotoSize photoSize;
 - (void)setMaxMinZoomScalesForCurrentBounds;
@@ -79,7 +33,7 @@
   // The photo view to be zoomed.
   UIImageView* _imageView;
   // The scroll view.
-  NICenteringScrollView* _scrollView;
+  UIScrollView* _scrollView;
   UIActivityIndicatorView* _loadingView;
 
   // Photo Information
@@ -103,7 +57,7 @@
     self.doubleTapToZoomIsEnabled = YES;
 
     // Autorelease so that we don't have to worry about releasing the subviews in dealloc.
-    _scrollView = [[NICenteringScrollView alloc] initWithFrame:self.bounds];
+    _scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
     _scrollView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
                                     | UIViewAutoresizingFlexibleHeight);
 
@@ -147,6 +101,10 @@
 
 - (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView {
   return _imageView;
+}
+
+- (void)scrollViewDidZoom:(UIScrollView *)scrollView {
+  [self centerImageView];
 }
 
 #pragma mark - Gesture Recognizers
@@ -505,6 +463,38 @@
   [self restoreCenterPoint:restorePoint scale:restoreScale];
 
   [_scrollView setNeedsLayout];
+}
+
+#pragma mark Centering
+
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  [self centerImageView];
+}
+
+- (void)centerImageView {
+  // Center the image as it becomes smaller than the size of the screen.
+  CGSize boundsSize = self.bounds.size;
+  CGRect frameToCenter = _imageView.frame;
+
+  // Center horizontally.
+  if (frameToCenter.size.width < boundsSize.width) {
+    frameToCenter.origin.x = NICGFloatFloor((boundsSize.width - frameToCenter.size.width) / 2);
+
+  } else {
+    frameToCenter.origin.x = 0;
+  }
+
+  // Center vertically.
+  if (frameToCenter.size.height < boundsSize.height) {
+    frameToCenter.origin.y = NICGFloatFloor((boundsSize.height - frameToCenter.size.height) / 2);
+
+  } else {
+    frameToCenter.origin.y = 0;
+  }
+
+  _imageView.frame = frameToCenter;
 }
 
 @end


### PR DESCRIPTION
When double tapping to zoom in, zooming behavior is broken because NICenteringScrollView tries to relayout during transition. This PR fixes this issue by moving centering logic from NICenteringScrollView to scrollViewDidZoom: and removes the class declaration which is no longer necessary.

Before: https://drive.google.com/open?id=1Uh8zR8mULhfWdgu5EWQ_jqujSuAF08sK
After: https://drive.google.com/open?id=1BHVaQ5XAGnqQ5U7-w9a9ujwA8Km8u7x-

This PR also contains one-liner commit to set scrollView's contentInsetAdjustmentBehavior property to never, to avoid unnecessary content offset visible on devices with safe area.