### PR TITLE
Fix remote test failure cased by a typo.

### DIFF
--- a/src/collections/src/NICollectionViewModel.m
+++ b/src/collections/src/NICollectionViewModel.m
@@ -187,7 +187,7 @@
   if (@available(iOS 10.0, *)) {
     NSMutableArray<id>* objects = [NSMutableArray array];
     for (NSIndexPath* indexPath in indexPaths) {
-      id object = [self objectAtIndexPath:indexPaths];
+      id object = [self objectAtIndexPath:indexPath];
       [objects addObject:object];
     }
     
@@ -199,7 +199,7 @@
   if (@available(iOS 10.0, *)) {
     NSMutableArray<id>* objects = [NSMutableArray array];
     for (NSIndexPath* indexPath in indexPaths) {
-      id object = [self objectAtIndexPath:indexPaths];
+      id object = [self objectAtIndexPath:indexPath];
       [objects addObject:object];
     }
   


### PR DESCRIPTION
A bit weird why this doesn't trigger any warning or compiling error locally.