### PR TITLE
Updated podspec dependencies to point to AFNetworking 3.0.

### DIFF
--- a/Nimbus.podspec
+++ b/Nimbus.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
     ss.source_files = 'src/css/src'
     ss.dependency 'Nimbus/Core'
     ss.dependency 'Nimbus/Textfield'
-    ss.dependency 'AFNetworking', '~> 2.6'
+    ss.dependency 'AFNetworking', '~> 3.0'
   end
 
   s.subspec 'Interapp' do |ss|
@@ -79,7 +79,7 @@ Pod::Spec.new do |s|
   s.subspec 'NetworkImage' do |ss|
     ss.source_files = 'src/networkimage/src'
     ss.dependency 'Nimbus/Core'
-    ss.dependency 'AFNetworking', '~> 2.6'
+    ss.dependency 'AFNetworking', '~> 3.0'
   end
 
   s.subspec 'Overview' do |ss|


### PR DESCRIPTION
Without this change the old version of AFNetworking was being installed, which would prevent the project from compiling (due to AFNetworking 3 methods not being declared).