### PR TITLE
[webcontroller] Deprecate NIWebController.

### DIFF
--- a/src/webcontroller/src/NIWebController.h
+++ b/src/webcontroller/src/NIWebController.h
@@ -74,6 +74,7 @@
  *
  * @ingroup NimbusWebController
  */
+__deprecated_msg("No longer supported; please use WKWebView instead. This API will eventually be deleted.")
 @interface NIWebController : UIViewController <UIWebViewDelegate, UIActionSheetDelegate>
 
 // Designated initializer.


### PR DESCRIPTION
It is using UIWebView which reached end-of-life in iOS 12. NIWebController also does not support safe area insets, so we are deprecating and deleting this API. Please use WKWebView instead.

Closes https://github.com/jverkoey/nimbus/issues/713