### PR TITLE
Fix the AttributedLabel triggering the Undefined Behavior sanitizer

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.m
+++ b/src/attributedlabel/src/NIAttributedLabel.m
@@ -1563,6 +1563,9 @@ _NI_UIACTIONSHEET_DEPRECATION_SUPPRESSION_POP()
 
   CFArrayRef lines = CTFrameGetLines(self.textFrame);
   NSInteger numberOfLines = [self numberOfDisplayedLines];
+  if (!numberOfLines) {
+    return;
+  }
 
   BOOL truncatesLastLine = (self.lineBreakMode == NSLineBreakByTruncatingTail);
   CGPoint lineOrigins[numberOfLines];


### PR DESCRIPTION
The issue is that the code was creating a variable length array of size 0.

Addresses Google issue b/145611212