### PR TITLE
Fix for wrong accessibilityFrames in NIAttributedLabel (#621)

### DIFF
--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -127,6 +127,16 @@ extern NSString* const NIAttributedLabelLinkAttributeName; // Value is an NSText
 
 @property (nonatomic) NILinkOrdering linkOrdering; // Define how to sort links in the text. Default: NILinkOrderFirst
 
+/**
+ * Configures if the label's accessibility elements should remember their last valid accessibility
+ * containers.
+ *
+ * When this property is set to @c YES, the label's accessibility elements will remember their last
+ * valid containers and use those containers if needed when computing accessibility properties like
+ * @c accessibilityFrame.
+ */
+@property(nonatomic) BOOL accessibleElementsRememberLastValidContainer;
+
 - (void)setFont:(UIFont *)font            range:(NSRange)range;
 - (void)setStrokeColor:(UIColor *)color   range:(NSRange)range;
 - (void)setStrokeWidth:(CGFloat)width     range:(NSRange)range;

--- a/src/attributedlabel/src/NIAttributedLabel.h
+++ b/src/attributedlabel/src/NIAttributedLabel.h
@@ -129,11 +129,24 @@ extern NSString* const NIAttributedLabelLinkAttributeName; // Value is an NSText
 
 /**
  * Configures if the label's accessibility elements should remember their last valid accessibility
- * containers.
+ * containers (Default: @c NO)
  *
- * When this property is set to @c YES, the label's accessibility elements will remember their last
- * valid containers and use those containers if needed when computing accessibility properties like
- * @c accessibilityFrame.
+ * An accessibility element in a @c NIAttributedLabel considers its accessibility container to be
+ * valid if it knows its frame inside the container. While an element has a valid container, it can
+ * dynamically compute its accessibility properties (e.g. @c accessibilityFrame) upon request to
+ * ensure such properties are correct even if the label's position on screen changes.
+ *
+ * UIKit sometimes spontaneously changes the accessibility containers of all accessibility elements
+ * in a @c NIAttributedLabel to another view. When this happens, the elements no longer know their
+ * frames inside the new container, so they must fall back to static accessibility properties that
+ * were computed on init. Those values only remain correct as long as their label's position on
+ * screen remains unchanged since they were computed. If the label is embedded inside a scroll view,
+ * those values will quickly become stale.
+ *
+ * Setting this property to @c YES allows @c NIAttributedLabel's accessibility elements to remember
+ * their last valid containers. When asked for their accessibility properties, if they no longer
+ * have a valid container, they will attempt to use their last valid containers for dynamic
+ * computations if possible before defaulting to fallback static values.
  */
 @property(nonatomic) BOOL accessibleElementsRememberLastValidContainer;
 


### PR DESCRIPTION
UIKit sometimes changes the accessibility containers of all accessibility
elements in a NIAttributedLabel to another view. I have observed this happening
when an NIAttributedLabel is embedded within a UICollectionViewCell, in which
case the newly assigned accessibility container is always the cell itself. I am
unsure why this happens.

We do compute a fallback value for accessibilityFrame for each
NIViewAccessibilityElement we create, but they become invalid as soon as the
label's position on screen changes. This frequently happens when the label is
embedded within a scroll view like UICollectionView.

When an NIViewAccessibilityElement has an invalid accessibilityFrame, its
activation point also becomes invalid, causing it to be untappable by VoiceOver
users.

This PR allows NIViewAccessibilityElement to remember its last valid
accessibility container upon request. When computing a dynamic accessibility
property like accessibleFrame, it will attempt to use the last valid
accessibility container it remembers if there is one instead of falling back to
super.