### PR TITLE
Remove NIFormCellCatalog from the umbrella header

### DIFF
--- a/src/models/src/NimbusModels.h
+++ b/src/models/src/NimbusModels.h
@@ -480,7 +480,6 @@ typedef enum {
 #import "NICellBackgrounds.h"
 #import "NICellCatalog.h"
 #import "NICellFactory.h"
-#import "NIFormCellCatalog.h"
 #import "NIRadioGroup.h"
 #import "NIRadioGroupController.h"
 #import "NITableViewActions.h"


### PR DESCRIPTION
This is being done in an effort to break the models library up into smaller pieces. To continue using the form cell catalog, its header will need to be imported directly.

Internal context CL: [cl/317411257](http://cl/317411257)